### PR TITLE
refactor(js): retire asDynamic, standardize unsupported-API signaling; tooling fixes

### DIFF
--- a/buildSrc/src/main/kotlin/filament-kmp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/filament-kmp-module.gradle.kts
@@ -12,13 +12,6 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-// Prevent Dokka from injecting 80MB+ of duplicated HTML docs into Maven Central publications.
-// We configure its generated javadoc JAR tasks to exclude all files, yielding empty JARs
-// which still satisfy Maven Central's requirement for a -javadoc.jar artifact.
-tasks.withType<org.gradle.jvm.tasks.Jar>().matching { it.name.endsWith("DokkaJavadocJar") }.configureEach {
-    exclude("**/*")
-}
-
 // ── Project coordinates (previously in root allprojects {}) ───────────────────
 group   = project.findProperty("projectGroup") as? String ?: "io.github.erkko68.filament"
 version = project.findProperty("libVersion")   as? String ?: "0.1.0-SNAPSHOT"

--- a/buildSrc/src/main/kotlin/filament-kmp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/filament-kmp-module.gradle.kts
@@ -12,6 +12,13 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
+// Prevent Dokka from injecting 80MB+ of duplicated HTML docs into Maven Central publications.
+// We configure its generated javadoc JAR tasks to exclude all files, yielding empty JARs
+// which still satisfy Maven Central's requirement for a -javadoc.jar artifact.
+tasks.withType<org.gradle.jvm.tasks.Jar>().matching { it.name.endsWith("DokkaJavadocJar") }.configureEach {
+    exclude("**/*")
+}
+
 // ── Project coordinates (previously in root allprojects {}) ───────────────────
 group   = project.findProperty("projectGroup") as? String ?: "io.github.erkko68.filament"
 version = project.findProperty("libVersion")   as? String ?: "0.1.0-SNAPSHOT"
@@ -167,13 +174,15 @@ afterEvaluate {
 }
 
 // ── Android defaults ──────────────────────────────────────────────────────────
+// SDK levels are single-sourced from gradle/libs.versions.toml so the catalog,
+// convention plugin, and docs can't silently drift apart.
 android {
     val groupStr = project.group.toString()
     val modulePart = project.name.replace("-", ".")
     namespace  = "$groupStr.$modulePart"
-    compileSdk = 36
+    compileSdk = libs.findVersion("android-compileSdk").get().requiredVersion.toInt()
     defaultConfig {
-        minSdk = 24
+        minSdk = libs.findVersion("android-minSdk").get().requiredVersion.toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 }

--- a/buildSrc/src/main/kotlin/filament-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/filament-publish.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
@@ -5,6 +7,15 @@ plugins {
 }
 
 mavenPublishing {
+    // Ship an empty -javadoc.jar for the KMP modules. API docs are hosted on GitHub Pages
+    // (Dokka), and Maven Central only requires the artifact to exist — not have content. This
+    // also avoids generating + bundling ~80MB of duplicated Dokka HTML into every target's jar,
+    // which is what the plugin does by default when Dokka is applied. The plain-JVM filament-ffm
+    // module isn't multiplatform and keeps the plugin's own default (already an empty javadoc jar).
+    if (pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
+        configure(KotlinMultiplatform(javadocJar = JavadocJar.Empty()))
+    }
+
     coordinates(project.group.toString(), project.name, project.version.toString())
 
     pom {

--- a/buildSrc/src/main/kotlin/filament-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/filament-publish.gradle.kts
@@ -4,11 +4,6 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-// Empty javadoc jar required by Maven Central.
-val javadocJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("javadoc")
-}
-
 mavenPublishing {
     coordinates(project.group.toString(), project.name, project.version.toString())
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 android-compileSdk = "36"
-android-minSdk = "29"
+android-minSdk = "24"
 android-targetSdk = "36"
 androidx-activity = "1.13.0"
 annotations = "26.1.0"

--- a/kotlin/filament-compose/src/jsMain/kotlin/io/github/erkko68/filament/compose/internal/WebViewCompositor.kt
+++ b/kotlin/filament-compose/src/jsMain/kotlin/io/github/erkko68/filament/compose/internal/WebViewCompositor.kt
@@ -132,7 +132,7 @@ internal class WebViewCompositor private constructor(private val engine: Engine)
                 e.target.width = r.width
                 e.target.height = r.height
             }
-            ctx.asDynamic().drawImage(
+            ctx.drawImage(
                 canvas,
                 r.left.toDouble(), r.top.toDouble(), r.width.toDouble(), r.height.toDouble(),
                 0.0, 0.0, r.width.toDouble(), r.height.toDouble(),

--- a/kotlin/filament-utils/src/jsMain/kotlin/io/github/erkko68/filament/utils/KTX1Loader.js.kt
+++ b/kotlin/filament-utils/src/jsMain/kotlin/io/github/erkko68/filament/utils/KTX1Loader.js.kt
@@ -9,10 +9,11 @@ import io.github.erkko68.filament.js.IndirectLight as JSIndirectLight
 import io.github.erkko68.filament.js.Skybox as JSSkybox
 import org.khronos.webgl.ArrayBufferView
 import org.khronos.webgl.Int8Array
+import org.khronos.webgl.set
 
 private fun ByteArray.toArrayBufferView(): ArrayBufferView {
     val int8 = Int8Array(size)
-    forEachIndexed { i, b -> int8.asDynamic()[i] = b }
+    forEachIndexed { i, b -> int8[i] = b }
     return int8.unsafeCast<ArrayBufferView>()
 }
 

--- a/kotlin/filament-utils/src/jsMain/kotlin/io/github/erkko68/filament/utils/TextureLoader.js.kt
+++ b/kotlin/filament-utils/src/jsMain/kotlin/io/github/erkko68/filament/utils/TextureLoader.js.kt
@@ -6,6 +6,7 @@ import io.github.erkko68.filament.js.Texture as JSTexture
 import org.khronos.webgl.ArrayBufferView
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
+import org.khronos.webgl.set
 
 // Texture::Usage bits (filament/backend/DriverEnums.h). DEFAULT = UPLOADABLE | SAMPLEABLE.
 private const val UPLOADABLE = 0x0008
@@ -24,7 +25,7 @@ actual object TextureLoader {
         // Filament's embind decoders expect a Uint8Array view (a raw Int8Array is rejected with a
         // native BindingError); match the Uint8Array idiom used across the JS bindings.
         val int8 = Int8Array(buffer.size)
-        buffer.forEachIndexed { i, b -> int8.asDynamic()[i] = b }
+        buffer.forEachIndexed { i, b -> int8[i] = b }
         val arrayBuffer = Uint8Array(int8.buffer).unsafeCast<ArrayBufferView>()
 
         // The JS helper builds the texture then calls generateMipmaps(), but unlike the native loader
@@ -39,7 +40,7 @@ actual object TextureLoader {
         return try {
             val jsTexture: JSTexture? = when {
                 isKtx1(buffer) -> jsEngine.createTextureFromKtx1(arrayBuffer)
-                isKtx2(buffer) -> jsEngine.asDynamic().createTextureFromKtx2(arrayBuffer)
+                isKtx2(buffer) -> jsEngine.createTextureFromKtx2(arrayBuffer)
                 isPng(buffer) -> jsEngine.createTextureFromPng(arrayBuffer, options)
                 isJpeg(buffer) -> jsEngine.createTextureFromJpeg(arrayBuffer, options)
                 else -> null

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Engine.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Engine.kt
@@ -349,7 +349,7 @@ expect class Engine {
     fun isValidView(view: View): Boolean
     /** Validate a Scene. @return true if valid. */
     fun isValidScene(scene: Scene): Boolean
-    /** Validate a Fence. @return true if valid. */
+    /** Validate a Fence. @return true if valid. @throws UnsupportedOperationException on JS — Fence is unbound on web. */
     fun isValidFence(fence: Fence): Boolean
     /** Validate a RenderTarget. @return true if valid. */
     fun isValidRenderTarget(renderTarget: RenderTarget): Boolean
@@ -357,9 +357,9 @@ expect class Engine {
     fun isValidIndexBuffer(indexBuffer: IndexBuffer): Boolean
     /** Validate a VertexBuffer. @return true if valid. */
     fun isValidVertexBuffer(vertexBuffer: VertexBuffer): Boolean
-    /** Validate a SkinningBuffer. @return true if valid. */
+    /** Validate a SkinningBuffer. @return true if valid. @throws UnsupportedOperationException on JS — SkinningBuffer is unbound on web. */
     fun isValidSkinningBuffer(skinningBuffer: SkinningBuffer): Boolean
-    /** Validate a MorphTargetBuffer. @return true if valid. */
+    /** Validate a MorphTargetBuffer. @return true if valid. @throws UnsupportedOperationException on JS — MorphTargetBuffer is unbound on web. */
     fun isValidMorphTargetBuffer(morphTargetBuffer: MorphTargetBuffer): Boolean
     /** Validate an IndirectLight. @return true if valid. */
     fun isValidIndirectLight(ibl: IndirectLight): Boolean
@@ -375,7 +375,7 @@ expect class Engine {
     fun isValidColorGrading(colorGrading: ColorGrading): Boolean
     /** Validate a Texture. @return true if valid. */
     fun isValidTexture(texture: Texture): Boolean
-    /** Validate a Stream. @return true if valid. */
+    /** Validate a Stream. @return true if valid. @throws UnsupportedOperationException on JS — Stream is unbound on web. */
     fun isValidStream(stream: Stream): Boolean
     /** Validate a SwapChain. @return true if valid. */
     fun isValidSwapChain(swapChain: SwapChain): Boolean
@@ -415,7 +415,7 @@ expect class Engine {
     /** Destroy a Scene. */
     fun destroyScene(scene: Scene)
 
-    /** Create a Fence for GPU synchronization. */
+    /** Create a Fence for GPU synchronization. @throws UnsupportedOperationException on JS — fences are unbound on web. */
     fun createFence(): Fence
     /** Destroy a Fence. */
     fun destroyFence(fence: Fence)

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/LightManager.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/LightManager.kt
@@ -349,6 +349,7 @@ expect class LightManager {
      * Returns the number of light components (may include inactive/destroyed lights).
      * Check with EntityManager.isAlive() before use if needed.
      * @return Number of light components
+     * @throws UnsupportedOperationException on JS — getComponentCount is unbound in the web wrapper.
      */
     fun getComponentCount(): Int
 

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/MorphTargetBuffer.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/MorphTargetBuffer.kt
@@ -84,6 +84,7 @@ expect class MorphTargetBuffer {
          *
          * @param engine Engine to associate this MorphTargetBuffer with.
          * @return The newly created MorphTargetBuffer.
+         * @throws UnsupportedOperationException on JS — MorphTargetBuffer is unbound in the web wrapper.
          */
         fun build(engine: Engine): MorphTargetBuffer
     }

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/SkinningBuffer.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/SkinningBuffer.kt
@@ -49,6 +49,7 @@ expect class SkinningBuffer {
          *
          * @param engine Engine to associate this SkinningBuffer with
          * @return The newly created SkinningBuffer
+         * @throws UnsupportedOperationException on JS — SkinningBuffer is unbound in the web wrapper.
          */
         fun build(engine: Engine): SkinningBuffer
     }

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Stream.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Stream.kt
@@ -84,6 +84,7 @@ expect class Stream {
          *
          * @param engine Engine to associate this Stream with.
          * @return The newly created Stream.
+         * @throws UnsupportedOperationException on JS — Stream is unbound in the web wrapper.
          */
         fun build(engine: Engine): Stream
     }

--- a/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/FenceTest.kt
+++ b/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/FenceTest.kt
@@ -1,11 +1,12 @@
 package io.github.erkko68.filament
 
+import io.github.erkko68.filament.testsupport.IgnoreJs
 import io.github.erkko68.filament.testutils.FilamentTestFixture
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+@IgnoreJs // Fence is not bound in the web wrapper; createFence throws there.
 class FenceTest : FilamentTestFixture() {
     @Test
     fun testFenceLifecycle() {

--- a/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/MorphTargetBufferTest.kt
+++ b/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/MorphTargetBufferTest.kt
@@ -1,11 +1,13 @@
 package io.github.erkko68.filament
 
+import io.github.erkko68.filament.testsupport.IgnoreJs
 import io.github.erkko68.filament.testutils.FilamentTestFixture
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+@IgnoreJs // MorphTargetBuffer is not bound in the web wrapper; Builder.build throws there.
 class MorphTargetBufferTest : FilamentTestFixture() {
     @Test
     fun testMorphTargetBufferLifecycle() {

--- a/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/SkinningBufferTest.kt
+++ b/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/SkinningBufferTest.kt
@@ -1,11 +1,13 @@
 package io.github.erkko68.filament
 
+import io.github.erkko68.filament.testsupport.IgnoreJs
 import io.github.erkko68.filament.testutils.FilamentTestFixture
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+@IgnoreJs // SkinningBuffer is not bound in the web wrapper; Builder.build throws there.
 class SkinningBufferTest : FilamentTestFixture() {
     @Test
     fun testSkinningBufferLifecycle() {

--- a/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/StreamTest.kt
+++ b/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/StreamTest.kt
@@ -1,10 +1,12 @@
 package io.github.erkko68.filament
 
+import io.github.erkko68.filament.testsupport.IgnoreJs
 import io.github.erkko68.filament.testutils.FilamentTestFixture
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+@IgnoreJs // Stream is not bound in the web wrapper; Builder.build throws there.
 class StreamTest : FilamentTestFixture() {
     @Test
     fun testStreamLifecycle() {

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/BufferObject.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/BufferObject.js.kt
@@ -2,13 +2,14 @@ package io.github.erkko68.filament
 
 import io.github.erkko68.filament.js.BufferObject_BindingType
 import io.github.erkko68.filament.js.BufferObject as JSBufferObject
+import org.khronos.webgl.set
 
 actual class BufferObject(internal val jsBufferObject: JSBufferObject) {
     actual val byteCount: Int get() = jsBufferObject.getByteCount().toInt()
 
     private fun ByteArray.toUint8Array(): org.khronos.webgl.Uint8Array {
         val int8 = org.khronos.webgl.Int8Array(size)
-        forEachIndexed { i, b -> int8.asDynamic()[i] = b }
+        forEachIndexed { i, b -> int8[i] = b }
         return org.khronos.webgl.Uint8Array(int8.buffer)
     }
 

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Engine.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Engine.js.kt
@@ -57,12 +57,12 @@ actual class Engine private constructor(val jsEngine: JSEngine, val jsCanvas: HT
     actual fun isValidRenderer(renderer: Renderer): Boolean = jsEngine.isValidRenderer(renderer.jsRenderer)
     actual fun isValidView(view: View): Boolean = jsEngine.isValidView(view.jsView)
     actual fun isValidScene(scene: Scene): Boolean = jsEngine.isValidScene(scene.jsScene)
-    actual fun isValidFence(fence: Fence): Boolean = true // TODO(js): Fence not bound in jsbindings.cpp
+    actual fun isValidFence(fence: Fence): Boolean = jsUnsupported("Engine.isValidFence")
     actual fun isValidRenderTarget(renderTarget: RenderTarget): Boolean = jsEngine.isValidRenderTarget(renderTarget.jsRenderTarget)
     actual fun isValidIndexBuffer(indexBuffer: IndexBuffer): Boolean = jsEngine.isValidIndexBuffer(indexBuffer.jsIndexBuffer)
     actual fun isValidVertexBuffer(vertexBuffer: VertexBuffer): Boolean = jsEngine.isValidVertexBuffer(vertexBuffer.jsVertexBuffer)
-    actual fun isValidSkinningBuffer(skinningBuffer: SkinningBuffer): Boolean = true // TODO(js): SkinningBuffer not bound in jsbindings.cpp
-    actual fun isValidMorphTargetBuffer(morphTargetBuffer: MorphTargetBuffer): Boolean = true // TODO(js): MorphTargetBuffer not bound in jsbindings.cpp
+    actual fun isValidSkinningBuffer(skinningBuffer: SkinningBuffer): Boolean = jsUnsupported("Engine.isValidSkinningBuffer")
+    actual fun isValidMorphTargetBuffer(morphTargetBuffer: MorphTargetBuffer): Boolean = jsUnsupported("Engine.isValidMorphTargetBuffer")
     actual fun isValidIndirectLight(ibl: IndirectLight): Boolean = jsEngine.isValidIndirectLight(ibl.jsIndirectLight)
     actual fun isValidMaterial(material: Material): Boolean = jsEngine.isValidMaterial(material.jsMaterial)
     actual fun isValidMaterialInstance(material: Material, materialInstance: MaterialInstance): Boolean =
@@ -72,7 +72,7 @@ actual class Engine private constructor(val jsEngine: JSEngine, val jsCanvas: HT
     actual fun isValidSkybox(skybox: Skybox): Boolean = jsEngine.isValidSkybox(skybox.jsSkybox)
     actual fun isValidColorGrading(colorGrading: ColorGrading): Boolean = jsEngine.isValidColorGrading(colorGrading.jsColorGrading)
     actual fun isValidTexture(texture: Texture): Boolean = jsEngine.isValidTexture(texture.jsTexture)
-    actual fun isValidStream(stream: Stream): Boolean = true // TODO(js): Stream not bound in jsbindings.cpp
+    actual fun isValidStream(stream: Stream): Boolean = jsUnsupported("Engine.isValidStream")
     actual fun isValidSwapChain(swapChain: SwapChain): Boolean = jsEngine.isValidSwapChain(swapChain.jsSwapChain)
 
     actual fun createSwapChain(surface: NativeSurface): SwapChain {
@@ -143,9 +143,8 @@ actual class Engine private constructor(val jsEngine: JSEngine, val jsCanvas: HT
         jsEngine.destroyScene(scene.jsScene)
     }
 
-    actual fun createFence(): Fence {
-        return Fence()
-    }
+    actual fun createFence(): Fence =
+        jsUnsupported("Engine.createFence", "Fences gate GPU/CPU sync, which filament.js does not expose.")
 
     actual fun destroyFence(fence: Fence) {
     }
@@ -338,8 +337,8 @@ actual class Engine private constructor(val jsEngine: JSEngine, val jsCanvas: HT
         }
 
         actual fun getSteadyClockTimeNano(): Long {
-            val jsVal = JSEngine.getSteadyClockTimeNano().asDynamic()
-            val num = js("Number")(jsVal) as Double
+            // js("Number")(...) coerces a possible BigInt result down to a JS number.
+            val num = js("Number")(JSEngine.getSteadyClockTimeNano()) as Double
             return num.toLong()
         }
     }

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/IndexBuffer.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/IndexBuffer.js.kt
@@ -3,13 +3,14 @@ package io.github.erkko68.filament
 import io.github.erkko68.filament.js.IndexBuffer as JSIndexBuffer
 import io.github.erkko68.filament.js.`IndexBuffer_Builder` as JSIndexBufferBuilder
 import io.github.erkko68.filament.js.IndexBuffer_IndexType
+import org.khronos.webgl.set
 
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 actual class IndexBuffer(internal val jsIndexBuffer: JSIndexBuffer, actual val indexCount: Int = 0) {
 
     private fun ByteArray.toUint8Array(): org.khronos.webgl.Uint8Array {
         val int8 = org.khronos.webgl.Int8Array(size)
-        forEachIndexed { i, b -> int8.asDynamic()[i] = b }
+        forEachIndexed { i, b -> int8[i] = b }
         return org.khronos.webgl.Uint8Array(int8.buffer)
     }
 

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/JsUnsupported.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/JsUnsupported.kt
@@ -1,0 +1,29 @@
+package io.github.erkko68.filament
+
+/**
+ * Single signaling point for Filament APIs that are not bound on the JS/Web target.
+ *
+ * Some upstream APIs are simply absent from `filament.js` / `jsbindings.cpp`. The policy
+ * for those is to **fail loudly** rather than silently no-op or return a fake value, so a
+ * web caller can never mistake "did nothing" for "succeeded". Faithful local emulations
+ * (e.g. state mirrored in the wrapper that round-trips correctly) are *not* routed here —
+ * this is only for capabilities the web backend genuinely cannot provide.
+ *
+ * @param api human-readable name of the unbound API, e.g. `"SkinningBuffer.Builder.build"`.
+ * @param workaround optional hint pointing the caller at a supported alternative.
+ */
+/**
+ * True if [obj] has a callable member named [name] (own or inherited).
+ *
+ * Used to feature-detect optional filament.js methods without extracting the function — calling a
+ * detached embind method (e.g. `val f = view.setX; f(...)`) loses `this` and aborts with a native
+ * BindingError, so probe with this and then invoke as a normal method call.
+ */
+internal fun jsHasMember(obj: Any?, name: String): Boolean =
+    js("obj != null && typeof obj[name] === 'function'").unsafeCast<Boolean>()
+
+internal fun jsUnsupported(api: String, workaround: String? = null): Nothing {
+    val base = "$api is not available on the JS/Web target — it is not bound in upstream " +
+        "filament.js (jsbindings.cpp)."
+    throw UnsupportedOperationException(if (workaround != null) "$base $workaround" else base)
+}

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/LightManager.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/LightManager.js.kt
@@ -8,10 +8,7 @@ import io.github.erkko68.filament.js.LightManager_Instance as JSLightManagerInst
 
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 actual class LightManager(internal val jsLightManager: JSLightManager) {
-    actual fun getComponentCount(): Int {
-        // TODO(js): getComponentCount not exposed in jsbindings.cpp
-        return 0
-    }
+    actual fun getComponentCount(): Int = jsUnsupported("LightManager.getComponentCount")
 
     // Upstream LightManager binding doesn't expose `destroy(Entity)` —
     // components are usually torn down via `engine.destroyEntity`, but we

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Material.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Material.js.kt
@@ -1,6 +1,7 @@
 package io.github.erkko68.filament
 
 import io.github.erkko68.filament.js.Material as JSMaterial
+import org.khronos.webgl.set
 
 actual class Material(internal val jsMaterial: JSMaterial) {
     actual fun compile(
@@ -205,7 +206,7 @@ actual class Material(internal val jsMaterial: JSMaterial) {
             val payload = _payload ?: throw IllegalStateException("Material payload must be set")
             // Convert ByteArray to Uint8Array for JS
             val int8 = org.khronos.webgl.Int8Array(payload.size)
-            payload.forEachIndexed { i, b -> int8.asDynamic()[i] = b }
+            payload.forEachIndexed { i, b -> int8[i] = b }
             val uint8 = org.khronos.webgl.Uint8Array(int8.buffer)
             return Material(engine.jsEngine.createMaterial(uint8))
         }

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/MaterialInstance.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/MaterialInstance.js.kt
@@ -8,8 +8,21 @@ import io.github.erkko68.filament.js.StencilOperation
 import io.github.erkko68.filament.js.CompareFunc
 import io.github.erkko68.filament.js.CullingMode
 
+// Members the generated MaterialInstance external doesn't cover: the vector/array overloads
+// of setBoolParameter/setFloatParameter (the scalar forms are generated), and the optional
+// setScissor/unsetScissor (present only in newer filament.js, so feature-detected).
+private external interface JsMaterialInstanceExt {
+    fun setBoolParameter(name: String, value: Array<Boolean>)
+    fun setFloatParameter(name: String, value: Array<Number>)
+    // Declared as methods (not function-typed properties) so they keep their `this` binding when
+    // invoked — a detached embind method aborts with a native BindingError. Probed before calling.
+    fun setScissor(left: Int, bottom: Int, width: Int, height: Int)
+    fun unsetScissor()
+}
+
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 actual class MaterialInstance(internal val jsMaterialInstance: JSMaterialInstance) {
+    private val ext: JsMaterialInstanceExt get() = jsMaterialInstance.unsafeCast<JsMaterialInstanceExt>()
     actual val material: Material
         get() = js("{}").unsafeCast<Material>()
 
@@ -29,7 +42,7 @@ actual class MaterialInstance(internal val jsMaterialInstance: JSMaterialInstanc
     }
 
     actual fun setParameter(name: String, x: Boolean, y: Boolean) {
-        jsMaterialInstance.asDynamic().setBoolParameter(name, arrayOf(x, y))
+        ext.setBoolParameter(name, arrayOf(x, y))
     }
 
     actual fun setParameter(name: String, x: Float, y: Float) {
@@ -41,7 +54,7 @@ actual class MaterialInstance(internal val jsMaterialInstance: JSMaterialInstanc
     }
 
     actual fun setParameter(name: String, x: Boolean, y: Boolean, z: Boolean) {
-        jsMaterialInstance.asDynamic().setBoolParameter(name, arrayOf(x, y, z))
+        ext.setBoolParameter(name, arrayOf(x, y, z))
     }
 
     actual fun setParameter(name: String, x: Float, y: Float, z: Float) {
@@ -59,7 +72,7 @@ actual class MaterialInstance(internal val jsMaterialInstance: JSMaterialInstanc
         z: Boolean,
         w: Boolean
     ) {
-        jsMaterialInstance.asDynamic().setBoolParameter(name, arrayOf(x, y, z, w))
+        ext.setBoolParameter(name, arrayOf(x, y, z, w))
     }
 
     actual fun setParameter(name: String, x: Float, y: Float, z: Float, w: Float) {
@@ -86,7 +99,7 @@ actual class MaterialInstance(internal val jsMaterialInstance: JSMaterialInstanc
         count: Int
     ) {
         val sub = v.slice(offset until (offset + count)).toTypedArray()
-        jsMaterialInstance.asDynamic().setBoolParameter(name, sub)
+        ext.setBoolParameter(name, sub)
     }
 
     actual fun setParameter(
@@ -97,7 +110,7 @@ actual class MaterialInstance(internal val jsMaterialInstance: JSMaterialInstanc
         count: Int
     ) {
         val sub = v.slice(offset until (offset + count)).toTypedArray()
-        jsMaterialInstance.asDynamic().setFloatParameter(name, sub)
+        ext.setFloatParameter(name, sub as Array<Number>)
     }
 
     actual fun setParameter(
@@ -109,7 +122,7 @@ actual class MaterialInstance(internal val jsMaterialInstance: JSMaterialInstanc
     ) {
         val sub = v.slice(offset until (offset + count)).toTypedArray()
         when (type) {
-            FloatElement.FLOAT -> jsMaterialInstance.asDynamic().setFloatParameter(name, sub)
+            FloatElement.FLOAT -> ext.setFloatParameter(name, sub as Array<Number>)
             FloatElement.FLOAT2 -> jsMaterialInstance.setFloat2Parameter(name, sub as Array<Number>)
             FloatElement.FLOAT3 -> jsMaterialInstance.setFloat3Parameter(name, sub as Array<Number>)
             FloatElement.FLOAT4 -> jsMaterialInstance.setFloat4Parameter(name, sub as Array<Number>)
@@ -150,17 +163,11 @@ actual class MaterialInstance(internal val jsMaterialInstance: JSMaterialInstanc
     }
 
     actual fun setScissor(left: Int, bottom: Int, width: Int, height: Int) {
-        val jsInst = jsMaterialInstance.asDynamic()
-        if (jsInst.setScissor != null) {
-            jsInst.setScissor(left, bottom, width, height)
-        }
+        if (jsHasMember(jsMaterialInstance, "setScissor")) ext.setScissor(left, bottom, width, height)
     }
 
     actual fun unsetScissor() {
-        val jsInst = jsMaterialInstance.asDynamic()
-        if (jsInst.unsetScissor != null) {
-            jsInst.unsetScissor()
-        }
+        if (jsHasMember(jsMaterialInstance, "unsetScissor")) ext.unsetScissor()
     }
 
     actual fun setPolygonOffset(scale: Float, constant: Float) {

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/MorphTargetBuffer.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/MorphTargetBuffer.js.kt
@@ -59,14 +59,10 @@ actual class MorphTargetBuffer internal constructor(
             return this
         }
 
-        actual fun build(engine: Engine): MorphTargetBuffer {
-            return MorphTargetBuffer(
-                vertexCount = vertexCount,
-                count = count,
-                hasPositions = hasPositions,
-                hasTangents = hasTangents,
-                isCustomMorphingEnabled = isCustomMorphingEnabled,
+        actual fun build(engine: Engine): MorphTargetBuffer =
+            jsUnsupported(
+                "MorphTargetBuffer",
+                "Morph targets are handled internally by gltfio on web; the standalone API is unbound."
             )
-        }
     }
 }

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Renderer.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Renderer.js.kt
@@ -3,6 +3,22 @@ package io.github.erkko68.filament
 import io.github.erkko68.filament.js.Renderer as JSRenderer
 import io.github.erkko68.filament.js.`Renderer_ClearOptions` as JSRendererClearOptions
 
+// Renderer methods present only in some filament.js builds. Declared as methods (not function-typed
+// properties) so they're invoked as `obj.method(...)` and keep their `this` binding — embind throws
+// BindingError if the bound function is detached from its receiver. Presence is probed before calling.
+// readPixels has two arities (with/without a RenderTarget), so it gets one interface each.
+private external interface JsRendererExt {
+    fun copyFrame(dstSwapChain: io.github.erkko68.filament.js.SwapChain, dst: Viewport, src: Viewport, flags: Int)
+    fun skipNextFrames(frameCount: Int)
+}
+private external interface JsReadPixels {
+    fun readPixels(x: Int, y: Int, w: Int, h: Int, buffer: Texture.PixelBufferDescriptor)
+}
+private external interface JsReadPixelsRt {
+    fun readPixels(rt: io.github.erkko68.filament.js.RenderTarget, x: Int, y: Int, w: Int, h: Int, buffer: Texture.PixelBufferDescriptor)
+}
+
+@Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 actual class Renderer(internal val jsRenderer: JSRenderer, private val _engine: Engine? = null) {
     actual var displayInfo: DisplayInfo = DisplayInfo()
         set(value) {
@@ -80,10 +96,8 @@ actual class Renderer(internal val jsRenderer: JSRenderer, private val _engine: 
         srcViewport: Viewport,
         flags: Int
     ) {
-        val jsRend = jsRenderer.asDynamic()
-        if (jsRend.copyFrame != null) {
-            jsRend.copyFrame(dstSwapChain.jsSwapChain, dstViewport, srcViewport, flags)
-        }
+        if (jsHasMember(jsRenderer, "copyFrame"))
+            jsRenderer.unsafeCast<JsRendererExt>().copyFrame(dstSwapChain.jsSwapChain, dstViewport, srcViewport, flags)
     }
 
     actual fun readPixels(
@@ -93,10 +107,8 @@ actual class Renderer(internal val jsRenderer: JSRenderer, private val _engine: 
         height: Int,
         buffer: Texture.PixelBufferDescriptor
     ) {
-        val jsRend = jsRenderer.asDynamic()
-        if (jsRend.readPixels != null) {
-            jsRend.readPixels(xoffset, yoffset, width, height, buffer)
-        }
+        if (jsHasMember(jsRenderer, "readPixels"))
+            jsRenderer.unsafeCast<JsReadPixels>().readPixels(xoffset, yoffset, width, height, buffer)
     }
 
     actual fun readPixels(
@@ -107,17 +119,13 @@ actual class Renderer(internal val jsRenderer: JSRenderer, private val _engine: 
         height: Int,
         buffer: Texture.PixelBufferDescriptor
     ) {
-        val jsRend = jsRenderer.asDynamic()
-        if (jsRend.readPixels != null) {
-            jsRend.readPixels(renderTarget.jsRenderTarget, xoffset, yoffset, width, height, buffer)
-        }
+        if (jsHasMember(jsRenderer, "readPixels"))
+            jsRenderer.unsafeCast<JsReadPixelsRt>().readPixels(renderTarget.jsRenderTarget, xoffset, yoffset, width, height, buffer)
     }
 
     actual fun skipNextFrames(frameCount: Int) {
-        val jsRend = jsRenderer.asDynamic()
-        if (jsRend.skipNextFrames != null) {
-            jsRend.skipNextFrames(frameCount)
-        }
+        if (jsHasMember(jsRenderer, "skipNextFrames"))
+            jsRenderer.unsafeCast<JsRendererExt>().skipNextFrames(frameCount)
     }
 
     actual class DisplayInfo {

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/SkinningBuffer.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/SkinningBuffer.js.kt
@@ -37,8 +37,10 @@ actual class SkinningBuffer internal constructor(
             return this
         }
 
-        actual fun build(engine: Engine): SkinningBuffer {
-            return SkinningBuffer(boneCount = boneCount)
-        }
+        actual fun build(engine: Engine): SkinningBuffer =
+            jsUnsupported(
+                "SkinningBuffer",
+                "Bind skinning through RenderableManager.Builder, which gltfio drives internally on web."
+            )
     }
 }

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Stream.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Stream.js.kt
@@ -19,8 +19,7 @@ actual class Stream(internal val jsStream: Any?) {
             return this
         }
 
-        actual fun build(engine: Engine): Stream {
-            return Stream(null)
-        }
+        actual fun build(engine: Engine): Stream =
+            jsUnsupported("Stream", "External/native video streams have no web equivalent.")
     }
 }

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/SurfaceOrientation.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/SurfaceOrientation.js.kt
@@ -16,7 +16,7 @@ private fun FloatArray.toFloat32Array(): Float32Array {
 
 private fun ShortArray.toUint16Array(): Uint16Array {
     val ua = Uint16Array(size)
-    forEachIndexed { i, v -> ua.asDynamic()[i] = v.toInt() }
+    forEachIndexed { i, v -> ua[i] = v }
     return ua
 }
 

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Texture.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/Texture.js.kt
@@ -6,6 +6,18 @@ import io.github.erkko68.filament.js.`driver_PixelBufferDescriptor` as JSPixelBu
 import io.github.erkko68.filament.js.PixelDataFormat
 import io.github.erkko68.filament.js.PixelDataType
 import io.github.erkko68.filament.js.Texture_Builder as JSTextureBuilder
+import org.khronos.webgl.set
+
+// The generated Texture external only binds setImage(engine, level, pbd); the deep/sub-region
+// overload exists in filament.js but isn't emitted, so re-type it here instead of `asDynamic()`.
+private external interface JsTextureExt {
+    fun setImage(
+        engine: io.github.erkko68.filament.js.Engine,
+        level: Int, xoffset: Int, yoffset: Int, zoffset: Int,
+        width: Int, height: Int, depth: Int,
+        pbd: JSPixelBufferDescriptor,
+    )
+}
 
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 actual class Texture(val jsTexture: JSTexture) {
@@ -165,7 +177,7 @@ actual class Texture(val jsTexture: JSTexture) {
             // heap and returns a driver$PixelBufferDescriptor. The class itself is
             // `Filament.driver$PixelBufferDescriptor`; there's no `Filament.PixelBufferDescriptor`.
             val u8 = org.khronos.webgl.Int8Array(storage.size).also { arr ->
-                storage.forEachIndexed { i, b -> arr.asDynamic()[i] = b }
+                storage.forEachIndexed { i, b -> arr[i] = b }
             }
             val typed = org.khronos.webgl.Uint8Array(u8.buffer)
             (js("Filament").PixelBuffer)(typed, mapFormat(format), mapType(type)).unsafeCast<JSPixelBufferDescriptor>()
@@ -237,7 +249,9 @@ actual class Texture(val jsTexture: JSTexture) {
         descriptor: PixelBufferDescriptor
     ) {
         // Deep setImage is for 3D textures or arrays
-        jsTexture.asDynamic().setImage(engine.jsEngine, level, xoffset, yoffset, zoffset, width, height, depth, descriptor.jsPbd)
+        jsTexture.unsafeCast<JsTextureExt>().setImage(
+            engine.jsEngine, level, xoffset, yoffset, zoffset, width, height, depth, descriptor.jsPbd
+        )
     }
 
     actual fun setExternalStream(

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/VertexBuffer.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/VertexBuffer.js.kt
@@ -4,13 +4,14 @@ import io.github.erkko68.filament.js.VertexBuffer as JSVertexBuffer
 import io.github.erkko68.filament.js.`VertexBuffer_Builder` as JSVertexBufferBuilder
 import io.github.erkko68.filament.js.VertexAttribute as JSVertexAttribute
 import io.github.erkko68.filament.js.VertexBuffer_AttributeType as JSVertexBufferAttributeType
+import org.khronos.webgl.set
 
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 actual class VertexBuffer(internal val jsVertexBuffer: JSVertexBuffer, actual val vertexCount: Int = 0) {
 
     private fun ByteArray.toUint8Array(): org.khronos.webgl.Uint8Array {
         val int8 = org.khronos.webgl.Int8Array(size)
-        forEachIndexed { i, b -> int8.asDynamic()[i] = b }
+        forEachIndexed { i, b -> int8[i] = b }
         return org.khronos.webgl.Uint8Array(int8.buffer)
     }
 

--- a/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/View.js.kt
+++ b/kotlin/filament/src/jsMain/kotlin/io/github/erkko68/filament/View.js.kt
@@ -2,7 +2,36 @@ package io.github.erkko68.filament
 
 import io.github.erkko68.filament.js.View as JSView
 
+// Optional View setters/getter present only in newer filament.js builds. Declared as methods
+// (not function-typed properties) so they're invoked as `obj.method(...)` and keep their `this`
+// binding — embind throws BindingError if the bound function is detached from its receiver.
+// Presence is probed with `jsHasMember` before calling.
+private external interface JsViewExt {
+    fun setDithering(dithering: io.github.erkko68.filament.js.View_Dithering)
+    fun setDynamicResolutionOptions(options: io.github.erkko68.filament.js.View_DynamicResolutionOptions)
+    fun setRenderQuality(quality: io.github.erkko68.filament.js.View_RenderQuality)
+    fun setShadowType(type: io.github.erkko68.filament.js.View_ShadowType)
+    fun setVsmShadowOptions(options: io.github.erkko68.filament.js.View_VsmShadowOptions)
+    fun setSoftShadowOptions(options: io.github.erkko68.filament.js.View_SoftShadowOptions)
+    fun getColorGrading(): io.github.erkko68.filament.js.ColorGrading?
+}
+
+// Value-object fields not emitted into the generated option externals.
+private external interface BloomOptionsExt {
+    var highlight: Number
+    var dirt: io.github.erkko68.filament.js.Texture?
+    var dirtStrength: Number
+}
+private external interface FogOptionsExt {
+    var densityMap: io.github.erkko68.filament.js.Texture?
+}
+private external interface AoOptionsExt {
+    var ssct: io.github.erkko68.filament.js.View_AmbientOcclusionOptions_Ssct
+}
+
+@Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 actual class View(internal val jsView: JSView) {
+    private val ext: JsViewExt get() = jsView.unsafeCast<JsViewExt>()
     private var _scene: Scene? = null
     private var _camera: Camera? = null
     private var _viewport: Viewport = Viewport(0, 0, 0, 0)
@@ -25,6 +54,7 @@ actual class View(internal val jsView: JSView) {
     private var _multiSampleAntiAliasingOptions = MultiSampleAntiAliasingOptions()
     private var _shadowType = ShadowType.PCF
     private var _renderTarget: RenderTarget? = null
+    private var _postProcessingEnabled = true
 
     // View::getName/setName aren't bound in upstream jsbindings.cpp (v1.71.4) —
     // track locally so the common getter/setter round-trip works.
@@ -81,9 +111,14 @@ actual class View(internal val jsView: JSView) {
 
     actual fun getVisibleLayers(): Int = _visibleLayersValues
 
+    // getView().isPostProcessingEnabled isn't bound upstream; the setter is, so mirror
+    // the value locally for a correct getter/setter round-trip (default: enabled).
     actual var isPostProcessingEnabled: Boolean
-        get() = true // TODO(js): getter not exposed in jsbindings.cpp; assume enabled
-        set(value) { jsView.setPostProcessingEnabled(value) }
+        get() = _postProcessingEnabled
+        set(value) {
+            _postProcessingEnabled = value
+            jsView.setPostProcessingEnabled(value)
+        }
 
     actual var antiAliasing: AntiAliasing
         get() = _antiAliasing
@@ -103,10 +138,7 @@ actual class View(internal val jsView: JSView) {
                 Dithering.NONE -> io.github.erkko68.filament.js.View_Dithering.NONE
                 Dithering.TEMPORAL -> io.github.erkko68.filament.js.View_Dithering.TEMPORAL
             }
-            val jsViewExt = jsView.asDynamic()
-            if (jsViewExt.setDithering != null) {
-                jsViewExt.setDithering(jsDith)
-            }
+            if (jsHasMember(jsView, "setDithering")) ext.setDithering(jsDith)
         }
 
     actual var dynamicResolutionOptions: DynamicResolutionOptions
@@ -125,10 +157,7 @@ actual class View(internal val jsView: JSView) {
                 View.Quality.HIGH -> io.github.erkko68.filament.js.View_QualityLevel.HIGH
                 View.Quality.ULTRA -> io.github.erkko68.filament.js.View_QualityLevel.ULTRA
             }
-            val jsViewExt = jsView.asDynamic()
-            if (jsViewExt.setDynamicResolutionOptions != null) {
-                jsViewExt.setDynamicResolutionOptions(jsOptions)
-            }
+            if (jsHasMember(jsView, "setDynamicResolutionOptions")) ext.setDynamicResolutionOptions(jsOptions)
         }
 
     actual var renderQuality: RenderQuality
@@ -144,10 +173,7 @@ actual class View(internal val jsView: JSView) {
             }
             // Push to the JS view — without this the setter was a silent no-op and the
             // hdrColorBuffer quality stayed at whatever Filament.js defaults to.
-            val jsViewExt = jsView.asDynamic()
-            if (jsViewExt.setRenderQuality != null) {
-                jsViewExt.setRenderQuality(jsQuality)
-            }
+            if (jsHasMember(jsView, "setRenderQuality")) ext.setRenderQuality(jsQuality)
         }
 
     actual var bloomOptions: BloomOptions
@@ -164,9 +190,11 @@ actual class View(internal val jsView: JSView) {
                 View.BloomOptions.BlendMode.ADD -> io.github.erkko68.filament.js.View_BloomOptions_BlendMode.ADD
                 View.BloomOptions.BlendMode.INTERPOLATE -> io.github.erkko68.filament.js.View_BloomOptions_BlendMode.INTERPOLATE
             }
-            jsOptions.asDynamic().highlight = value.highlight
-            jsOptions.asDynamic().dirt = value.dirt?.jsTexture
-            jsOptions.asDynamic().dirtStrength = value.dirtStrength
+            jsOptions.unsafeCast<BloomOptionsExt>().let {
+                it.highlight = value.highlight
+                it.dirt = value.dirt?.jsTexture
+                it.dirtStrength = value.dirtStrength
+            }
             jsView.setBloomOptions(jsOptions)
         }
 
@@ -186,7 +214,7 @@ actual class View(internal val jsView: JSView) {
             jsOptions.inScatteringStart = value.inScatteringStart
             jsOptions.inScatteringSize = value.inScatteringSize
             jsOptions.fogColorFromIbl = value.fogColorFromIbl
-            jsOptions.asDynamic().densityMap = value.densityMap?.jsTexture
+            jsOptions.unsafeCast<FogOptionsExt>().densityMap = value.densityMap?.jsTexture
             jsView.setFogOptions(jsOptions)
         }
 
@@ -238,7 +266,7 @@ actual class View(internal val jsView: JSView) {
             jsSsct.lightConeRad = value.ssct.lightConeRad
             jsSsct.shadowDistance = value.ssct.shadowDistance
             jsSsct.contactDistanceMax = value.ssct.contactDistanceMax
-            jsOptions.asDynamic().ssct = jsSsct
+            jsOptions.unsafeCast<AoOptionsExt>().ssct = jsSsct
             
             jsView.setAmbientOcclusionOptions(jsOptions)
         }
@@ -281,17 +309,14 @@ actual class View(internal val jsView: JSView) {
         get() = _shadowType
         set(value) {
             _shadowType = value
-            val jsViewExt = jsView.asDynamic()
-            if (jsViewExt.setShadowType != null) {
-                val jsType = when(value) {
-                    ShadowType.PCF -> io.github.erkko68.filament.js.View_ShadowType.PCF
-                    ShadowType.VSM -> io.github.erkko68.filament.js.View_ShadowType.VSM
-                    ShadowType.DPCF -> io.github.erkko68.filament.js.View_ShadowType.DPCF
-                    ShadowType.PCSS -> io.github.erkko68.filament.js.View_ShadowType.PCSS
-                    ShadowType.PCFd -> io.github.erkko68.filament.js.View_ShadowType.PCFd
-                }
-                jsViewExt.setShadowType(jsType)
+            val jsType = when(value) {
+                ShadowType.PCF -> io.github.erkko68.filament.js.View_ShadowType.PCF
+                ShadowType.VSM -> io.github.erkko68.filament.js.View_ShadowType.VSM
+                ShadowType.DPCF -> io.github.erkko68.filament.js.View_ShadowType.DPCF
+                ShadowType.PCSS -> io.github.erkko68.filament.js.View_ShadowType.PCSS
+                ShadowType.PCFd -> io.github.erkko68.filament.js.View_ShadowType.PCFd
             }
+            if (jsHasMember(jsView, "setShadowType")) ext.setShadowType(jsType)
         }
 
     actual var vsmShadowOptions: VsmShadowOptions
@@ -304,10 +329,7 @@ actual class View(internal val jsView: JSView) {
             jsOptions.msaaSamples = value.msaaSamples
             jsOptions.highPrecision = value.highPrecision
             jsOptions.lightBleedReduction = value.lightBleedReduction
-            val jsViewExt = jsView.asDynamic()
-            if (jsViewExt.setVsmShadowOptions != null) {
-                jsViewExt.setVsmShadowOptions(jsOptions)
-            }
+            if (jsHasMember(jsView, "setVsmShadowOptions")) ext.setVsmShadowOptions(jsOptions)
         }
 
     actual var softShadowOptions: SoftShadowOptions
@@ -317,10 +339,7 @@ actual class View(internal val jsView: JSView) {
             val jsOptions = js("{}").unsafeCast<io.github.erkko68.filament.js.`View_SoftShadowOptions`>()
             jsOptions.penumbraScale = value.penumbraScale
             jsOptions.penumbraRatioScale = value.penumbraRatioScale
-            val jsViewExt = jsView.asDynamic()
-            if (jsViewExt.setSoftShadowOptions != null) {
-                jsViewExt.setSoftShadowOptions(jsOptions)
-            }
+            if (jsHasMember(jsView, "setSoftShadowOptions")) ext.setSoftShadowOptions(jsOptions)
         }
 
     actual var guardBandOptions: GuardBandOptions
@@ -408,7 +427,7 @@ actual class View(internal val jsView: JSView) {
 
     actual var colorGrading: ColorGrading?
         get() {
-            val jsColorGrading = jsView.asDynamic().getColorGrading()
+            val jsColorGrading = if (jsHasMember(jsView, "getColorGrading")) ext.getColorGrading() else null
             return if (jsColorGrading != null) ColorGrading(jsColorGrading) else null
         }
         set(value) {

--- a/kotlin/gltfio/src/jsMain/kotlin/io/github/erkko68/filament/gltfio/AssetLoader.js.kt
+++ b/kotlin/gltfio/src/jsMain/kotlin/io/github/erkko68/filament/gltfio/AssetLoader.js.kt
@@ -4,10 +4,11 @@ import io.github.erkko68.filament.Engine
 import io.github.erkko68.filament.EntityManager
 import io.github.erkko68.filament.js.`gltfio_AssetLoader` as JSAssetLoader
 import io.github.erkko68.filament.js.Engine as JSEngine
+import org.khronos.webgl.set
 
 private fun ByteArray.toUint8Array(): org.khronos.webgl.Uint8Array {
     val int8 = org.khronos.webgl.Int8Array(size)
-    forEachIndexed { i, b -> int8.asDynamic()[i] = b }
+    forEachIndexed { i, b -> int8[i] = b }
     return org.khronos.webgl.Uint8Array(int8.buffer)
 }
 

--- a/kotlin/gltfio/src/jsMain/kotlin/io/github/erkko68/filament/gltfio/ResourceLoader.js.kt
+++ b/kotlin/gltfio/src/jsMain/kotlin/io/github/erkko68/filament/gltfio/ResourceLoader.js.kt
@@ -2,11 +2,24 @@ package io.github.erkko68.filament.gltfio
 
 import io.github.erkko68.filament.Engine
 import io.github.erkko68.filament.js.assets
+import org.khronos.webgl.set
 
 private fun ByteArray.toUint8Array(): org.khronos.webgl.Uint8Array {
     val int8 = org.khronos.webgl.Int8Array(size)
-    forEachIndexed { i, b -> int8.asDynamic()[i] = b }
+    forEachIndexed { i, b -> int8[i] = b }
     return org.khronos.webgl.Uint8Array(int8.buffer)
+}
+
+// The generated external types loadResources with all callbacks required; the real
+// filament.js signature has them optional. Re-type it permissively so callers can omit
+// args without dropping to `asDynamic()`.
+private external interface JsLoadResources {
+    fun loadResources(
+        onDone: (() -> Unit)? = definedExternally,
+        onFetched: ((url: String) -> Unit)? = definedExternally,
+        basePath: String? = definedExternally,
+        asyncInterval: Number? = definedExternally,
+    )
 }
 
 actual class ResourceLoader actual constructor(engine: Engine, normalizeSkinningWeights: Boolean) {
@@ -31,7 +44,7 @@ actual class ResourceLoader actual constructor(engine: Engine, normalizeSkinning
         // Delegate to the JS FilamentAsset's built-in loadResources which handles
         // WASM resource loader creation, buffer uploads, and async texture decoding.
         // This is required even for .glb files to upload vertex data to WebGL.
-        asset.jsAsset.asDynamic().loadResources()
+        asset.jsAsset.unsafeCast<JsLoadResources>().loadResources()
         return true
     }
 
@@ -56,9 +69,9 @@ actual class ResourceLoader actual constructor(engine: Engine, normalizeSkinning
             // On JS, loadResources is asynchronous. We use the callback to set progress to 1.0.
             // We set it to 0.1 initially so the calling loop knows we are working.
             loadProgress = 0.1f
-            asset.jsAsset.asDynamic().loadResources({
+            asset.jsAsset.unsafeCast<JsLoadResources>().loadResources(onDone = {
                 loadProgress = 1f
-            }, null, null, null)
+            })
         }
     }
 

--- a/samples/gradle/libs.versions.toml
+++ b/samples/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 android-compileSdk = "36"
-android-minSdk = "29"
+android-minSdk = "24"
 android-targetSdk = "36"
 androidx-activity = "1.13.0"
 annotations = "26.1.0"


### PR DESCRIPTION
Clears several finished pre-1.0 backlog items. No public-API behavior change on JVM/Android/iOS; the JS target gains stricter, type-safe interop and loud signaling for genuinely unbound APIs.

## JS interop — retire `asDynamic()` (#11)
Replaced type-unsafe `asDynamic()` interop with typed `external interface` overlays for filament.js members the generated externals don't cover (`View` optional setters / `getColorGrading`, `Renderer` `copyFrame`/`readPixels`/`skipNextFrames`, `MaterialInstance` vector/scissor overloads, `Texture.setImage`, gltfio `loadResources`).

Optional embind methods are declared as interface **methods** and probed with `jsHasMember(...)` before calling, so the bound function keeps its `this` receiver. Invoking a *detached* embind method (`val f = view.setX; f(...)`) loses `this` and aborts with a native `BindingError` — this caught and fixed a real regression in the round-trip / lifecycle tests for `View`, `Renderer`, and `MaterialInstance`.

The only remaining `asDynamic` sites are writes into the upstream **read-only** `assets` `Record` in `ResourceLoader`, which has no typed write path.

## JS unsupported-API signaling (#10)
Added `jsUnsupported()` / `jsHasMember()` in `JsUnsupported.kt`. Truly-unbound web APIs (`Stream`/`Fence`/`SkinningBuffer`/`MorphTargetBuffer` construction, the matching `Engine.isValid*` queries, `LightManager.getComponentCount`) now **throw** instead of returning sentinels, so a web caller can't mistake a silent no-op for success. Affected standalone-object tests are gated.

## Tooling — single-source SDK levels (#4)
`minSdk`/`compileSdk` are now read from `gradle/libs.versions.toml` in the convention plugin (was hardcoded `24` vs. catalog `29` — the catalog value was both dead and wrong). Same drift fixed in the samples catalog.

## Publish
Dropped the manual empty javadoc jar; instead empty Dokka's generated javadoc JARs — avoids ~80MB of duplicated HTML in Maven Central artifacts while still satisfying the `-javadoc.jar` requirement.

## Testing
JVM + full JS suites pass locally (`scripts/dev/run-tests.sh jvm js`).
