### PR TITLE
docs: add SECURITY.md and architecture diagram

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+Filament KMP is a **Kotlin Multiplatform wrapper** around
+[Google Filament](https://github.com/google/filament). That shapes its security model: the
+heavy, memory-unsafe work — rendering, shader/material compilation, backend drivers, and
+asset parsing (glTF, KTX, images) — happens inside the **native Filament engine** we ship as
+prebuilt binaries, not in this repository. Please read the triage section below before
+reporting; it usually decides *where* a vulnerability belongs.
+
+## Supported versions
+
+This project is pre-1.0 and ships frequent beta releases. Only the **latest published
+release** receives security fixes. Older betas are not patched — upgrade to the newest
+version first and confirm the issue still reproduces.
+
+| Version | Supported |
+| :-- | :-- |
+| Latest release | ✅ |
+| Older / pre-release | ❌ |
+
+## Is it this wrapper, or Filament?
+
+Same rule of thumb as [CONTRIBUTING.md](CONTRIBUTING.md): *if the same symptom would happen
+from C++/JS using Filament directly, it is an engine issue.*
+
+- **Engine vulnerabilities** — crashes, memory corruption, or unsafe parsing triggered by a
+  malformed model/texture/material, backend (GL/Metal/Vulkan/WebGPU) faults, or anything
+  inside the native engine — should be reported to
+  [google/filament](https://github.com/google/filament/security). These reproduce
+  independently of Kotlin. We track such issues with the `upstream-filament` label and refresh
+  our prebuilts once a fix lands upstream.
+- **Wrapper vulnerabilities** belong here. These are the parts we actually own:
+  - the hand-written native glue (C wrapper, JNI, Project-Panama/FFM bindings) and the
+    Kotlin/JS externals — e.g. incorrect buffer sizing in out-parameters, marshalling bugs,
+    or type-unsafe JS interop;
+  - the build/prebuilt plumbing — integrity of the Filament binaries downloaded per
+    `filaVersion`, and the download scripts under `scripts/`;
+  - packaging, signing, and publishing of the released artifacts.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security vulnerability.**
+
+Use GitHub's **private vulnerability reporting** for this repository:
+[**Report a vulnerability**](https://github.com/Erkko68/filament-kmp/security/advisories/new).
+This opens a private advisory visible only to the maintainers.
+
+Please include, as far as you can:
+
+- affected version(s) and platform/target (Android, iOS, JVM/Desktop, Web);
+- a minimal reproduction, and whether it also reproduces against Filament directly (this tells
+  us if it is a wrapper or an engine issue);
+- impact and any known workaround.
+
+## What to expect
+
+- **Acknowledgement** within a few days.
+- An assessment of whether the issue is a wrapper bug (fixed here) or an upstream engine bug
+  (escalated to Google Filament and tracked via `upstream-filament`).
+- A fix or mitigation in the next release once validated, with credit to the reporter unless
+  you prefer to remain anonymous.
+
+Because this is a small, pre-1.0 project, timelines are best-effort. Thanks for helping keep
+Filament KMP and its users safe.

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -2,6 +2,43 @@
 
 The `filament-kmp` project is organized into several modules to handle the cross-platform nature of the Filament engine.
 
+## Architecture at a glance
+
+One shared `expect` surface in `commonMain` fans out into four platform `actual`
+implementations, each bound to the native engine by a different mechanism. Everything above
+the dashed line is Kotlin we maintain; everything below is the upstream Google Filament engine.
+
+```mermaid
+flowchart TB
+    subgraph common["kotlin/ · commonMain — one expect surface"]
+        API["filament · filamat · gltfio · filament-utils<br/>filament-compose (Compose MP UI)"]
+    end
+
+    API --> AND["androidMain<br/>(actual)"]
+    API --> JVM["jvmMain<br/>(actual)"]
+    API --> NAT["iosMain / macosMain<br/>(actual)"]
+    API --> WEB["jsMain<br/>(actual)"]
+
+    AND -->|official AAR| MAVEN["com.google.android.filament<br/>Maven artifact"]
+    JVM -->|jextract → FFM| FFM["java/ · libfilament-c<br/>(shared, built from c/)"]
+    NAT -->|cinterop| CIN["c/ wrapper<br/>(per-module static libs)"]
+    WEB -->|Karakum externals<br/>from filament.d.ts| JS["js/ · Filament.js (WASM)"]
+
+    FFM --> CWRAP["c/ — C-ABI over Filament C++"]
+    CIN --> CWRAP
+
+    CWRAP -.-> ENGINE
+    MAVEN -.-> ENGINE
+    JS -.-> ENGINE
+
+    subgraph upstream["Google Filament (upstream)"]
+        ENGINE["Native engine + prebuilt binaries<br/>(prebuilts/ · include/ · downloaded per filaVersion)"]
+    end
+```
+
+See [Binding Strategy by Platform](#binding-strategy-by-platform) below for the same mapping
+in table form.
+
 ## Core Modules
 
 - **`c/`**: C++ wrapper that exposes a C-compatible ABI around the official Filament C++ API. Consumed by two code generators: **Kotlin Native** targets (iOS, macOS) via `cinterop` (one CMake library per sub-module — `libfilament-c.a`, `libfilamat-c.a`, `libfilament-utils-c.a`, `libgltfio-c.a`), and the **JVM/Desktop** target via `jextract` (the `FILAMENT_BUILD_SHARED` path links all four into one `libfilament-c` shared image). Each module's C-ABI types live in its own `*Types.h` header (core types in `filament/c/FilaTypes.h`).


### PR DESCRIPTION
Two community-health / docs enhancements surfaced by the project evaluation (§1 and backlog #15).

## SECURITY.md
A security policy shaped around the fact that this is a **thin wrapper**, not a renderer:

- **Routes reports by ownership.** Malformed-asset crashes / native-engine memory bugs → [google/filament](https://github.com/google/filament/security) (tracked here via `upstream-filament`); the C/JNI/FFM glue, JS externals, prebuilt-download plumbing, and packaging → reported here. Mirrors the existing "is it the wrapper or Filament?" triage in CONTRIBUTING and the issue-template config.
- **Private reporting** via GitHub Security Advisories — no inbox to staff.
- **Support scope** limited to the latest release (pre-1.0 / beta).

> Note: the advisory link only works once **Private Vulnerability Reporting** is enabled in repo Settings → Security.

## Architecture diagram
An "Architecture at a glance" **Mermaid** diagram in `docs/repo-structure.md` (renders natively on GitHub, no committed image): one `commonMain` expect surface → four platform actuals → their distinct binding mechanisms (Maven AAR / jextract-FFM / cinterop / Karakum) → the upstream engine + prebuilts. A dashed line separates "Kotlin we own" from upstream Filament. Cross-links to the existing binding-strategy table.

Docs-only; no code or build changes.