### PR TITLE
ci(dependabot): group updates per ecosystem to cut PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
         patterns:
           - "com.android*"
           - "androidx.*"
+      # Catch-all (incl. the Gradle wrapper). A dependency joins the first matching
+      # group, so the named groups above claim theirs and this sweeps the rest into
+      # one PR instead of one-per-dependency.
+      gradle:
+        patterns:
+          - "*"
 
   # Samples is a separate Gradle build with its own settings.gradle.kts.
   - package-ecosystem: "gradle"
@@ -25,9 +31,17 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      samples:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Problem

Dependabot is opening **one PR per dependency** for the github-actions and `/samples` ecosystems (~10 single-bump PRs open right now: #12–22, #24, #25). Only the root Gradle build had grouping configured.

## Fix

Add catch-all `groups` so each ecosystem collapses to a few combined PRs:

- **Root Gradle**: keep the `kotlin` / `compose` / `android` groups, add a `gradle` catch-all (`["*"]`) that sweeps the Gradle wrapper and anything not in the named groups. A dependency joins the *first* matching group, so the named groups still claim theirs.
- **`/samples` Gradle**: new `samples` group (`["*"]`) → 1 PR.
- **github-actions**: new `actions` group (`["*"]`) → 1 PR.

Net result: from ~10 PRs/run down to at most ~6 (4 root-gradle groups + samples + actions), and usually fewer.

## Rollout note

This only takes effect once merged to `main` (Dependabot reads config from the default branch). On its next run Dependabot supersedes the existing singleton PRs with grouped ones and closes the old ones — or trigger it immediately from **Insights → Dependency graph → Dependabot → Check for updates**. The current open singleton PRs can be left to be auto-closed or closed manually.

Trade-off: grouped PRs bundle major and minor bumps together. If isolating majors becomes desirable later, we can split groups by `update-types`.