### PR TITLE
fix(web): resolve JsArray type collision under Kotlin 2.4.0

### DIFF
--- a/kotlin/filament/src/webMain/kotlin/io/github/erkko68/filament/MaterialInstance.js.kt
+++ b/kotlin/filament/src/webMain/kotlin/io/github/erkko68/filament/MaterialInstance.js.kt
@@ -4,7 +4,7 @@ import io.github.erkko68.filament.web.interop.toJsBooleans
 
 import io.github.erkko68.filament.web.interop.emptyJsObject
 
-import js.array.JsArray
+import js.array.ReadonlyArray
 
 import io.github.erkko68.filament.web.interop.jsNumbers
 import io.github.erkko68.filament.web.interop.toJsNumbers
@@ -21,8 +21,8 @@ import io.github.erkko68.filament.web.CullingMode
 // of setBoolParameter/setFloatParameter (the scalar forms are generated), and the optional
 // setScissor/unsetScissor (present only in newer filament.js, so feature-detected).
 private external interface JsMaterialInstanceExt : JsAny  {
-    fun setBoolParameter(name: String, value: JsArray<JsBoolean>)
-    fun setFloatParameter(name: String, value: JsArray<JsNumber>)
+    fun setBoolParameter(name: String, value: ReadonlyArray<JsBoolean>)
+    fun setFloatParameter(name: String, value: ReadonlyArray<JsNumber>)
     // Declared as methods (not function-typed properties) so they keep their `this` binding when
     // invoked — a detached embind method aborts with a native BindingError. Probed before calling.
     fun setScissor(left: Int, bottom: Int, width: Int, height: Int)

--- a/web/src/webMain/kotlin/io/github/erkko68/filament/web/interop/JsArrays.kt
+++ b/web/src/webMain/kotlin/io/github/erkko68/filament/web/interop/JsArrays.kt
@@ -1,76 +1,61 @@
 package io.github.erkko68.filament.web.interop
 
 import js.array.JsArray
+import js.array.ReadonlyArray
+import js.array.jsArrayOf
+import js.array.toJsArray as toJsReadonlyArray
 
 /**
- * Marshaling helpers between Kotlin number collections and the JS `number[]` arrays
- * that Filament.js expects for vector/matrix parameters (typed `float3`/`mat4`/… =
- * `JsAny?` in the externals). Written against kotlin-wrappers `JsArray<JsNumber>`,
- * which is multiplatform (js + wasmJs) and is a `ReadonlyArray<JsNumber>` supertype,
- * so a single helper feeds both the `JsAny?` and `ReadonlyArray<JsNumber>` externals.
+ * Marshaling helpers between Kotlin number collections and the JS `number[]` arrays that
+ * Filament.js expects for vector/matrix parameters. The generated externals type these as
+ * `JsAny?` (`float3`/`mat4`/…) or `ReadonlyArray<JsNumber>`, so the builders return the
+ * common `js.array.ReadonlyArray`, constructed via `jsArrayOf` — the mutable `js.array.JsArray`
+ * has no constructor in the shared `webMain` metadata compile, and its bare `JsArray()` /
+ * `unsafeCast<JsArray<…>>` forms would bind to stdlib `kotlin.js.JsArray` under Kotlin 2.4.0.
  */
 
 // `Number` vararg/elements are fine here — they're only converted, never crossing the
-// JS interop boundary (that's `JsArray<JsNumber>`), so wasmJs's ban on `Number` interop
-// doesn't apply.
-fun jsNumbers(vararg values: Number): JsArray<JsNumber> {
-    val arr = JsArray<JsNumber>()
-    values.forEachIndexed { i, v -> arr[i] = v.toDouble().toJsNumber() }
-    return arr
-}
+// JS interop boundary (that's `JsNumber`), so wasmJs's ban on `Number` interop doesn't apply.
+fun jsNumbers(vararg values: Number): ReadonlyArray<JsNumber> =
+    jsArrayOf(*Array(values.size) { values[it].toDouble().toJsNumber() })
 
-fun FloatArray.toJsNumbers(): JsArray<JsNumber> {
-    val arr = JsArray<JsNumber>()
-    forEachIndexed { i, v -> arr[i] = v.toDouble().toJsNumber() }
-    return arr
-}
+fun FloatArray.toJsNumbers(): ReadonlyArray<JsNumber> =
+    jsArrayOf(*Array(size) { this[it].toDouble().toJsNumber() })
 
-fun DoubleArray.toJsNumbers(): JsArray<JsNumber> {
-    val arr = JsArray<JsNumber>()
-    forEachIndexed { i, v -> arr[i] = v.toJsNumber() }
-    return arr
-}
+fun DoubleArray.toJsNumbers(): ReadonlyArray<JsNumber> =
+    jsArrayOf(*Array(size) { this[it].toJsNumber() })
 
-fun List<Number>.toJsNumbers(): JsArray<JsNumber> {
-    val arr = JsArray<JsNumber>()
-    forEachIndexed { i, v -> arr[i] = v.toDouble().toJsNumber() }
-    return arr
-}
+fun List<Number>.toJsNumbers(): ReadonlyArray<JsNumber> =
+    jsArrayOf(*Array(size) { this[it].toDouble().toJsNumber() })
 
 /** Reads a JS `number[]` (as returned by Filament.js) into a DoubleArray of [size]. */
 fun JsArray<JsNumber>.toDoubleArray(size: Int): DoubleArray =
-    DoubleArray(size) { i -> this[i]?.toDouble() ?: 0.0 }
+    DoubleArray(size) { i -> this[i].toDouble() }
 
 /** Reads a JS `number[]` value (typed `JsAny?` in the externals) into a FloatArray of [size]. */
 fun JsAny.toFloatArray(size: Int): FloatArray {
-    val arr = unsafeCast<JsArray<JsNumber>>()
-    return FloatArray(size) { i -> arr[i]?.toDouble()?.toFloat() ?: 0f }
+    val arr = unsafeCast<js.array.JsArray<JsNumber>>()
+    return FloatArray(size) { i -> arr[i].toDouble().toFloat() }
 }
 
 /** Reads a JS `number[]` value into an existing [out] FloatArray (up to its size). */
 fun JsAny.readNumbersInto(out: FloatArray): FloatArray {
-    val arr = unsafeCast<JsArray<JsNumber>>()
-    for (i in 0 until minOf(out.size, arr.length)) out[i] = arr[i]?.toDouble()?.toFloat() ?: 0f
+    val arr = unsafeCast<js.array.JsArray<JsNumber>>()
+    for (i in 0 until minOf(out.size, arr.size)) out[i] = arr[i].toDouble().toFloat()
     return out
 }
 
 /** Reads a JS `number[]` value into an existing [out] DoubleArray (up to its size). */
 fun JsAny.readNumbersInto(out: DoubleArray): DoubleArray {
-    val arr = unsafeCast<JsArray<JsNumber>>()
-    for (i in 0 until minOf(out.size, arr.length)) out[i] = arr[i]?.toDouble() ?: 0.0
+    val arr = unsafeCast<js.array.JsArray<JsNumber>>()
+    for (i in 0 until minOf(out.size, arr.size)) out[i] = arr[i].toDouble()
     return out
 }
 
-/** Wraps a Kotlin list of JS values into a real JS array (`JsArray<T>`). */
-fun <T : JsAny?> List<T>.toJsArray(): JsArray<T> {
-    val arr = JsArray<T>()
-    forEachIndexed { i, v -> arr[i] = v }
-    return arr
-}
+/** Wraps a Kotlin list of JS values into a real JS array. */
+fun <T : JsAny?> List<T>.toJsArray(): ReadonlyArray<T> =
+    toJsReadonlyArray()
 
 /** A JS boolean array (Filament.js material bool-array params). */
-fun List<Boolean>.toJsBooleans(): JsArray<JsBoolean> {
-    val arr = JsArray<JsBoolean>()
-    forEachIndexed { i, v -> arr[i] = v.toJsBoolean() }
-    return arr
-}
+fun List<Boolean>.toJsBooleans(): ReadonlyArray<JsBoolean> =
+    jsArrayOf(*Array(size) { this[it].toJsBoolean() })


### PR DESCRIPTION
## Problem

The dependabot **Kotlin 2.3.21 → 2.4.0** bump (#45) broke the pages CI at `:web:compileWebMainKotlinMetadata`:

```
e: JsArrays.kt: Return type mismatch: expected 'js.array.JsArray<JsNumber>', actual 'kotlin.js.JsArray<JsNumber>'.
```

Kotlin 2.4.0 now surfaces stdlib **`kotlin.js.JsArray`** alongside the explicitly-imported kotlin-wrappers **`js.array.JsArray`** in the shared `webMain` metadata compile, so the `JsArray<T>()` constructions and `.length`/`unsafeCast` sites in `JsArrays.kt` mis-bind to the stdlib type.

The underlying constraint: `js.array.JsArray` is an **expect class with no constructor** (and no `.length`) in the common metadata compile — those only exist in the per-platform actuals. The old bare `JsArray<T>()` only ever compiled by silently binding to `kotlin.js.JsArray`.

## Fix

Rewrite the marshaling helpers against the common kotlin-wrappers API every consumer already expects:

- **Builders** (`jsNumbers`, `toJsNumbers`, `toJsBooleans`, `toJsArray`) return `js.array.ReadonlyArray<…>`, built via `jsArrayOf` / the wrappers `List.toJsArray()`. The generated externals all take `ReadonlyArray<T>` (arrays) or `JsAny?` (`float3`/`mat4` vectors), so this is assignable everywhere.
- **Readers** (`toFloatArray`, `readNumbersInto`, `toDoubleArray`) keep `js.array.JsArray` but use `.size` instead of the platform-only `.length`.
- Retype the project-owned `JsMaterialInstanceExt` array params (`setBoolParameter`/`setFloatParameter`) to `ReadonlyArray<…>`.

No call sites change — widening the returns to `ReadonlyArray` is transparent.

> Note: previously merged as #51 into `feat/wasm-support`; re-targeting to `main` since that branch merged (#48) before this fix landed.