### PR TITLE
fix(web): use common .size for kotlin-wrappers arrays in gltfio webMain

### DIFF
--- a/kotlin/gltfio/src/webMain/kotlin/io/github/erkko68/filament/gltfio/FilamentAsset.js.kt
+++ b/kotlin/gltfio/src/webMain/kotlin/io/github/erkko68/filament/gltfio/FilamentAsset.js.kt
@@ -21,7 +21,7 @@ actual class FilamentAsset(
     }
 
     private fun js.array.ReadonlyArray<JSEntity>.registerAndGetIds(): IntArray {
-        return IntArray(length) { i -> this[i]!!.registerAndGetId() }
+        return IntArray(size) { i -> this[i]!!.registerAndGetId() }
     }
 
     actual fun getRoot(): Entity = jsAsset.getRoot().registerAndGetId()
@@ -88,7 +88,7 @@ actual class FilamentAsset(
 
     actual fun getResourceUris(): Array<String> {
         val uris = jsAsset.getResourceUris()
-        return Array(uris.length) { uris[it].toString() }
+        return Array(uris.size) { uris[it].toString() }
     }
 
     actual fun releaseSourceData() {

--- a/kotlin/gltfio/src/webMain/kotlin/io/github/erkko68/filament/gltfio/FilamentInstance.js.kt
+++ b/kotlin/gltfio/src/webMain/kotlin/io/github/erkko68/filament/gltfio/FilamentInstance.js.kt
@@ -93,7 +93,7 @@ actual class FilamentInstance(internal val jsInstance: JSFilamentInstance) {
 
     actual fun getMaterialVariantNames(): Array<String> {
         val names = jsInstance.getMaterialVariantNames()
-        return Array(names.length) { names[it].toString() }
+        return Array(names.size) { names[it].toString() }
     }
 
     actual constructor() : this(emptyJsObject().unsafeCast<JSFilamentInstance>()) {


### PR DESCRIPTION
Fixes the failing Pages run (`Generate API docs`): `:kotlin:gltfio:compileWebMainKotlinMetadata` breaks under Kotlin 2.4.0 because `.length` on kotlin-wrappers arrays is platform-only and metadata compilation resolves it against the expect declaration. Same fix as #52 (`JsArrays.kt`), at the three remaining call sites in gltfio's webMain — the common API is `.size`.

Verified locally: `./gradlew dokkaGenerate --no-configuration-cache` succeeds end-to-end on this branch.