### PR TITLE
fix(build): stop compiling Android bytecode at JVM 22

### DIFF
--- a/buildSrc/src/main/kotlin/filament-kmp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/filament-kmp-module.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import java.awt.GraphicsEnvironment
 
@@ -28,6 +27,9 @@ val filamentModuleExt = extensions.create("filamentModule", FilamentModuleExtens
 
 val libs = the<org.gradle.api.artifacts.VersionCatalogsExtension>().named("libs")
 
+fun catalogJvmTarget(alias: String): JvmTarget =
+    JvmTarget.fromTarget(libs.findVersion(alias).get().requiredVersion)
+
 // ── Kotlin multiplatform target declarations ──────────────────────────────────
 kotlin {
     compilerOptions {
@@ -45,8 +47,12 @@ kotlin {
         compileSdk = libs.findVersion("android-compileSdk").get().requiredVersion.toInt()
         minSdk     = libs.findVersion("android-minSdk").get().requiredVersion.toInt()
 
-        // Android bytecode level (JVM_22) is set globally via the
-        // `tasks.withType<KotlinJvmCompile>` block below.
+        // Android must NOT inherit the desktop JVM 22 floor: inline functions
+        // (math utils etc.) compiled at 22 can't inline into consumers building
+        // at the conventional Android target (issue #1).
+        compilerOptions {
+            jvmTarget.set(catalogJvmTarget("android-jvmTarget"))
+        }
 
         // Instrumented (on-device) tests inherit from `commonTest` (sourceSetTree
         // "test") so the shared `expect`s (createTestSurface, TestMaterials) line up
@@ -61,7 +67,17 @@ kotlin {
     // Declare all targets
     iosArm64()
     iosSimulatorArm64()
-    jvm()
+
+    // JVM/Panama floor: jvmMain actuals call java.lang.foreign (finalized in JDK 22)
+    // and depend on :java. The Gradle daemon runs on JDK 25
+    // (gradle/gradle-daemon-jvm.properties), so no per-module toolchain is needed —
+    // just pin the bytecode floor so the artifact stays usable on any JDK 22+.
+    // Scoped to this target only; Android above stays at its own lower target.
+    jvm {
+        compilerOptions {
+            jvmTarget.set(catalogJvmTarget("jvm-target"))
+        }
+    }
 
     js {
         browser { binaries.executable() }
@@ -107,16 +123,6 @@ kotlin {
             }
         }
     }
-}
-
-// ── JVM/Panama floor ──────────────────────────────────────────────────────────
-// The jvmMain actuals call java.lang.foreign (finalized in JDK 22) and depend on
-// :java. The Gradle daemon runs on JDK 25 (gradle/gradle-daemon-jvm.properties), so
-// the toolchain and the requested org.gradle.jvm.version are already 22+ — no per-module toolchain
-// or attribute forcing is needed. We only pin the jvm bytecode to a JVM 22 floor so the artifact
-// stays usable on any JDK 22+ (Android/native/JS targets are untouched — different task types).
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_22)
 }
 
 // ── Real-backend (GPU) test gating, decided once here on the host ─────────────

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,11 @@ agp = "9.0.1"
 android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
+# Android bytecode level — the conventional Android target; higher values break inlining
+# for consumers compiling at 11 (issue #1).
+android-jvmTarget = "11"
+# Desktop jvm() bytecode floor — jvmMain actuals need java.lang.foreign (finalized JDK 22).
+jvm-target = "22"
 androidx-activity = "1.13.0"
 annotations = "26.1.0"
 composeMultiplatform = "1.11.1"

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -21,12 +21,14 @@ plugins {
 // before it finalizes coordinates).
 
 // FFM was finalized in JDK 22. The Gradle daemon runs on JDK 25 (gradle/gradle-daemon-jvm.properties),
-// so we just pin a JVM 22 release floor here to keep the published artifact usable on any JDK 22+.
+// so we just pin the JVM release floor (libs.versions.toml `jvm-target`) to keep the
+// published artifact usable on any JDK 22+.
+val jvmRelease = libs.versions.jvm.target.get()
 tasks.withType<JavaCompile>().configureEach {
-    options.release.set(22)
+    options.release.set(jvmRelease.toInt())
 }
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_22)
+    compilerOptions.jvmTarget.set(JvmTarget.fromTarget(jvmRelease))
 }
 
 // ── Native build + jextract generation (see buildSrc/FilamentJvmNative.kt) ────


### PR DESCRIPTION
## Problem

Issue #1: consumers using inline math utils (`Float3.times`, `dot`, `cross`, ...) on Android hit:

```
Cannot inline bytecode built with JVM target 22 into bytecode that is being built with JVM target 11. Specify proper '-jvm-target' option.
```

The convention plugin (`filament-kmp-module.gradle.kts`) applied `jvmTarget = JVM_22` to **every** `KotlinJvmCompile` task — the Android target included — so published AARs shipped inline function bodies as JVM 22 bytecode.

## Fix

- Scope the JVM 22 floor (needed only for `java.lang.foreign` in `jvmMain`) to the `jvm()` target.
- Pin `androidLibrary` to JVM 11, the conventional Android target.
- Single-source both levels in `gradle/libs.versions.toml` (`android-jvmTarget = 11`, `jvm-target = 22`); `:java` (filament-ffm) now reads the same catalog entry instead of hardcoding 22.

## Verification

- `Float3.class` from `compileAndroidMain` is now class-file major version **55** (Java 11); the `jvm()` output stays **66** (Java 22).
- All six library modules compile for Android at the new target; all desktop JVM targets and `:java` still compile.
- End-to-end repro: a temporary `androidMain` file in `samples/shared` (JVM 11, builds against local sources via `includeBuild`) calling `Float3(1f,3f,5f).times(5f)` and `dot(...)` now compiles cleanly.

Fixes #1