### PR TITLE
feat(jvm): skiko-style native runtime — cached loader, sealed exports, build overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
         shell: bash
         run: |
           ./gradlew \
+            :java:test \
             :kotlin:filament:jvmTest \
             :kotlin:filamat:jvmTest \
             :kotlin:filament-utils:jvmTest \

--- a/buildSrc/src/main/kotlin/FilamentJvmNative.kt
+++ b/buildSrc/src/main/kotlin/FilamentJvmNative.kt
@@ -18,6 +18,7 @@ private const val JEXTRACT_MAJOR = "22"
  * @property dylibDir         build/cmake dir that holds the freshly built libfilament-c.{dylib,so,dll}
  * @property generatedJavaDir build/generated/jextract — jextract output, added to the jvm Java source set
  * @property platformArch     "{platform}-{arch}", e.g. "macos-arm64", used as the natives/ resource subdir
+ * @property buildType        CMake config, "Release" or "Debug" (-Pfilament.debug=true)
  * @property cmakeBuild       the task producing the dylib (depend on it from processResources)
  * @property jextract         the task producing the generated Java (depend on it from the jvm compile tasks)
  */
@@ -25,6 +26,7 @@ data class FilamentJvmNative(
     val dylibDir: Provider<Directory>,
     val generatedJavaDir: Provider<Directory>,
     val platformArch: String,
+    val buildType: String,
     val cmakeBuild: TaskProvider<Exec>,
     val jextract: TaskProvider<Exec>,
 )
@@ -67,12 +69,20 @@ fun Project.applyFilamentJvmNative(
     val cmakeBuildDir = layout.buildDirectory.dir("cmake").get().asFile
     val generatedDir = layout.buildDirectory.dir("generated/jextract").get().asFile
 
+    // Debug wrapper build via -Pfilament.debug=true. Prebuilts stay Release; on Windows the
+    // /MTd↔/MT CRT mismatch makes a Debug link against them fail — use macOS/Linux for this.
+    val buildType = if (findProperty("filament.debug") == "true") "Debug" else "Release"
+    // FILAMENT_PREBUILTS_DIR points the link at a locally built Filament (layout mirrors
+    // prebuilts/: <target>/lib) and skips the download task for that target.
+    val localPrebuilts = providers.environmentVariable("FILAMENT_PREBUILTS_DIR").orNull
+
     val downloadPrebuilts = rootProject.tasks.named("downloadPrebuilts_$prebuiltsTarget")
     val downloadIncludes = rootProject.tasks.named("downloadIncludes")
 
     // ── CMake: configure + build the combined SHARED library ──────────────────
     val cmakeConfigure = tasks.register("cmakeConfigureFilamentCJvm", Exec::class.java) {
-        dependsOn(downloadPrebuilts, downloadIncludes)
+        if (localPrebuilts == null) dependsOn(downloadPrebuilts)
+        dependsOn(downloadIncludes)
         doFirst { cmakeBuildDir.mkdirs() }
         workingDir(cmakeBuildDir)
         val args = mutableListOf(
@@ -80,8 +90,11 @@ fun Project.applyFilamentJvmNative(
             "-DFILAMENT_BUILD_SHARED=ON",
             "-DFILAMENT_PLATFORM=$platform",
             "-DFILAMENT_ARCH=$arch",
-            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_BUILD_TYPE=$buildType",
         )
+        if (localPrebuilts != null) {
+            args += "-DFILAMENT_LIB_DIR=${File(localPrebuilts, "$prebuiltsTarget/lib").absolutePath.replace('\\', '/')}"
+        }
         if (platform == "macos") {
             args += "-DCMAKE_OSX_SYSROOT=macosx"
             args += "-DCMAKE_OSX_ARCHITECTURES=${if (arch == "Arm64") "arm64" else "x86_64"}"
@@ -95,7 +108,7 @@ fun Project.applyFilamentJvmNative(
         // No output declarations: cmakeConfigure writes CMakeCache.txt into this same dir, so
         // declaring it as an output here would let Gradle wipe the cache before the build runs.
         // CMake's own incremental build keeps rebuilds cheap. (Matches java/filament.)
-        commandLine(cmakePath, "--build", ".", "--target", "filament-c-jvm", "--config", "Release")
+        commandLine(cmakePath, "--build", ".", "--target", "filament-c-jvm", "--config", buildType)
     }
 
     // ── jextract: download the tool, then generate the bindings ──────────────
@@ -162,6 +175,7 @@ fun Project.applyFilamentJvmNative(
         dylibDir = layout.buildDirectory.dir("cmake"),
         generatedJavaDir = layout.buildDirectory.dir("generated/jextract"),
         platformArch = platformArch,
+        buildType = buildType,
         cmakeBuild = cmakeBuild,
         jextract = jextract,
     )

--- a/buildSrc/src/main/kotlin/FilamentNative.kt
+++ b/buildSrc/src/main/kotlin/FilamentNative.kt
@@ -72,7 +72,15 @@ fun KotlinNativeTarget.applyFilamentNative(
     // same konan target, sharing one dir causes them to clobber each other's libfilament-c.a.
     val cmakeSourceDir = project.file("../../c")
     val buildDir       = project.file("../../c/build/$name/$cmakeTarget")
-    val prebuiltDir    = project.file("../../prebuilts/${platform.prebuiltDir}/lib")
+    // Debug wrapper build via -Pfilament.debug=true; FILAMENT_PREBUILTS_DIR swaps in a locally
+    // built Filament (layout mirrors prebuilts/: <target>/lib) and skips the download task.
+    val buildType      = if (project.findProperty("filament.debug") == "true") "Debug" else "Release"
+    val localPrebuilts = project.providers.environmentVariable("FILAMENT_PREBUILTS_DIR").orNull
+    val prebuiltDir    = if (localPrebuilts != null) {
+        java.io.File(localPrebuilts, "${platform.prebuiltDir}/lib")
+    } else {
+        project.file("../../prebuilts/${platform.prebuiltDir}/lib")
+    }
 
     // Prebuilt static libs are downloaded by a root-level task (see kotlin/build.gradle.kts).
     val downloadTask = project.rootProject.tasks.named("downloadPrebuilts_$name")
@@ -82,14 +90,15 @@ fun KotlinNativeTarget.applyFilamentNative(
     // CMake: configure + build the C wrapper in one step
     val cmake = resolveCmake()
     val cmakeTask = project.tasks.register("buildCWrapper_${cmakeTarget}_$name", Exec::class.java) {
-        dependsOn(downloadTask)
+        if (localPrebuilts == null) dependsOn(downloadTask)
         dependsOn(downloadIncludesTask)
         workingDir(buildDir)
         commandLine(
             "sh", "-c",
             "$cmake ${cmakeSourceDir.absolutePath} -DFILAMENT_PLATFORM=${platform.cmakePlatform}" +
             " -DFILAMENT_ARCH=${platform.cmakeArch}" +
-            " -DCMAKE_BUILD_TYPE=Release" +
+            " -DCMAKE_BUILD_TYPE=$buildType" +
+            " -DFILAMENT_LIB_DIR=${prebuiltDir.absolutePath}" +
             " && $cmake --build . --target $cmakeTarget",
         )
         val targetName = name

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -336,7 +336,8 @@ if (FILAMENT_BUILD_SHARED)
     )
 
     # A Windows DLL exports nothing unless told to, so loaderLookup() would find no symbols
-    # (macOS/Linux export by default).
+    # (macOS/Linux export by default). Left unsealed: DLL imports bind by (module, name),
+    # so surplus exports can't be interposed the way flat-namespace ELF/Mach-O ones can.
     set_target_properties(filament-c-jvm PROPERTIES
         OUTPUT_NAME "filament-c"
         WINDOWS_EXPORT_ALL_SYMBOLS ON)
@@ -376,6 +377,9 @@ if (FILAMENT_BUILD_SHARED)
             "-framework CoreVideo"
             "-framework OpenGL"
         )
+        # Seal: export only the Fila* C API; keep filament's C++ internals local
+        # (smaller symbol table, no clashes with other libs in the host process).
+        target_link_options(filament-c-jvm PRIVATE "LINKER:-exported_symbol,_Fila*")
     elseif (WIN32)
         # Statically link the MSVC C++ runtime (/MT) to avoid msvcp140.dll conflicts
         # with the JVM. The prebuilts downloaded by Gradle must also be the /MT versions.
@@ -408,5 +412,10 @@ if (FILAMENT_BUILD_SHARED)
             "LINKER:--start-group"
         )
         target_link_libraries(filament-c-jvm PRIVATE "-Wl,--end-group")
+        # Seal: same as the macOS -exported_symbol above, via a version script.
+        target_link_options(filament-c-jvm PRIVATE
+            "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/filament-c.map")
+        set_target_properties(filament-c-jvm PROPERTIES
+            LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/filament-c.map")
     endif()
 endif()

--- a/c/filament-c.map
+++ b/c/filament-c.map
@@ -1,0 +1,9 @@
+/* Seal the combined JVM shared lib: export only the Fila* C API (FFM loaderLookup
+   needs nothing else); filament::/utils:: C++ internals stay local to avoid symbol
+   clashes with other libs in the host process. macOS twin: -exported_symbol _Fila*. */
+{
+    global:
+        Fila*;
+    local:
+        *;
+};

--- a/java/README.md
+++ b/java/README.md
@@ -21,15 +21,34 @@ so consumers never add it by hand.
    `io.github.erkko68.filament.ffm.FilamentC` class of low-level `MethodHandle` bindings.
    The jextract task is wired as a source dir, so every consumer (`compileJava`,
    `compileKotlin`, `sourcesJar`) depends on it.
-3. The dylib is packaged into the JAR under `natives/<platform>-<arch>/`. At runtime
+3. The dylib is packaged into the JAR under `natives/<platform>-<arch>/` together with a
+   `.sha256` stamp. At runtime
    [`FilamentLoader`](src/main/java/io/github/erkko68/filament/ffm/FilamentLoader.java)
-   extracts it to a temp file and `System.load`s it so jextract's `loaderLookup` resolves
-   the symbols. No system install of Filament is needed.
+   extracts it **once** into a content-hash-keyed cache dir (`~/.filament-kmp/filament-c-<hash>/`)
+   and `System.load`s it from there, so jextract's `loaderLookup` resolves the symbols.
+   Subsequent JVM starts reuse the cached copy; concurrent processes are serialized by a
+   lock file; unused cache dirs are purged after 30 days. No system install of Filament
+   is needed. Runtime knobs (system properties):
+   - `filament.library.path` — load the lib from this directory instead of extracting.
+   - `filament.data.path` — cache root (default `~/.filament-kmp`).
+   - `filament.data.cleanup.days` — stale-cache purge age; `<= 0` disables (default 30).
 4. [`Ffm.kt`](src/main/kotlin/io/github/erkko68/filament/Ffm.kt) hosts the shared FFM
    helpers (arenas, struct/array marshalling, upcall stubs) that the `:kotlin:*` `jvmMain`
    actuals build their idiomatic Kotlin API on top of `FilamentC`.
 
 `jextract` is fetched automatically by the build (the `downloadJextract` task, cached under `.gradle/jextract/`) — no manual setup. The download script it wraps is [`scripts/gradle/download_jextract.py`](../scripts/gradle/download_jextract.py).
+
+Build knobs:
+- `-Pfilament.debug=true` — build the C wrapper with `CMAKE_BUILD_TYPE=Debug` (prebuilts
+  stay Release; on Windows the `/MTd`↔`/MT` CRT mismatch makes the Debug link fail, so
+  use macOS/Linux for this).
+- `FILAMENT_PREBUILTS_DIR=<dir>` (env) — link against a locally built Filament instead of
+  the downloaded prebuilts and skip the download task. Layout mirrors `prebuilts/`:
+  `<dir>/<target>/lib` (e.g. `<dir>/macosArm64/lib`). Also honoured by the Kotlin/Native
+  cinterop builds.
+- On macOS/Linux the shared lib is **sealed**: only the `Fila*` C API is exported
+  (see [`c/filament-c.map`](../c/filament-c.map)), keeping Filament's C++ internals out of
+  the process-wide symbol namespace.
 
 ## Requirements
 

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.security.MessageDigest
 
 plugins {
     `java-library`
@@ -72,8 +73,8 @@ tasks.named<ProcessResources>("processResources") {
         include("*.dylib", "*.so", "*.dll")
         into("natives/$platformArch")
     }
-    // Multi-config generators (Visual Studio) put DLLs in build/cmake/Release/.
-    from(ffm.dylibDir.map { it.dir("Release") }) {
+    // Multi-config generators (Visual Studio) put DLLs in build/cmake/<config>/.
+    from(ffm.dylibDir.map { it.dir(ffm.buildType) }) {
         include("*.dll")
         into("natives/$platformArch")
     }
@@ -89,8 +90,34 @@ tasks.named<ProcessResources>("processResources") {
             }
         }
     }
+    // Stamp each native with its sha256 — FilamentLoader keys its extraction cache dir by it.
+    doLast {
+        val md = MessageDigest.getInstance("SHA-256")
+        destinationDir.resolve("natives").walkTopDown()
+            .filter { it.isFile && it.extension in setOf("dylib", "so", "dll") }
+            .forEach { lib ->
+                md.reset()
+                lib.inputStream().use { ins ->
+                    val buf = ByteArray(64 * 1024)
+                    while (true) {
+                        val n = ins.read(buf)
+                        if (n < 0) break
+                        md.update(buf, 0, n)
+                    }
+                }
+                File(lib.path + ".sha256").writeText(md.digest().joinToString("") { "%02x".format(it) })
+            }
+    }
 }
 
 tasks.named("assemble") {
     dependsOn(ffm.cmakeBuild)
+}
+
+// ── Loader unit tests (extraction cache + stale-dir cleanup) ──────────────────
+dependencies {
+    testImplementation(libs.junit)
+}
+tasks.named<Test>("test") {
+    useJUnit()
 }

--- a/java/src/main/java/io/github/erkko68/filament/ffm/FilamentLoader.java
+++ b/java/src/main/java/io/github/erkko68/filament/ffm/FilamentLoader.java
@@ -2,13 +2,31 @@ package io.github.erkko68.filament.ffm;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileLock;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
- * Extracts the combined {@code libfilament-c} from this module's JAR resources to a temp
- * file and {@link System#load(String) loads} it.
+ * Locates and {@link System#load(String) loads} the combined {@code libfilament-c}.
+ *
+ * <p>Search order:
+ * <ol>
+ *   <li>{@code filament.library.path} system property — load from that directory as-is.</li>
+ *   <li>JAR resource {@code natives/<platform>-<arch>/} — extracted once into a
+ *       content-hash-keyed cache dir under {@code filament.data.path}
+ *       (default {@code ~/.filament-kmp}), then reused across JVM starts. Extraction is
+ *       guarded by a cross-process file lock; cache dirs for older builds are purged after
+ *       {@code filament.data.cleanup.days} (default 30, {@code <= 0} disables).</li>
+ *   <li>{@code System.loadLibrary} — dev fallback for a lib on {@code java.library.path}.</li>
+ * </ol>
  *
  * <p>The jextract-generated {@link FilamentC} class resolves symbols through
  * {@code SymbolLookup.loaderLookup()}, which finds symbols in native libraries loaded by
@@ -19,6 +37,7 @@ import java.nio.file.StandardCopyOption;
  */
 public final class FilamentLoader {
 
+    private static final String LIB_NAME = "filament-c";
     private static volatile boolean sLoaded = false;
 
     private FilamentLoader() {
@@ -28,59 +47,165 @@ public final class FilamentLoader {
     public static synchronized void load() {
         if (sLoaded) return;
         try {
-            String os = System.getProperty("os.name").toLowerCase();
-            String arch = System.getProperty("os.arch").toLowerCase();
-
-            String platform;
-            String extension;
-            String prefix = "lib";
-            if (os.contains("win")) {
-                platform = "windows";
-                extension = ".dll";
-                prefix = "";
-            } else if (os.contains("mac") || os.contains("darwin")) {
-                platform = "macos";
-                extension = ".dylib";
-            } else if (os.contains("nux") || os.contains("nix") || os.contains("aix")) {
-                platform = "linux";
-                extension = ".so";
-            } else {
-                throw new UnsupportedOperationException("Unsupported OS: " + os);
-            }
-
-            if (arch.contains("aarch64") || arch.contains("arm64")) {
-                arch = "arm64";
-            } else {
-                arch = "x64";
-            }
-
-            String libName = "filament-c";
-            String libFileName = prefix + libName + extension;
-            String resourcePath = "/natives/" + platform + "-" + arch + "/" + libFileName;
-
-            InputStream is = FilamentLoader.class.getResourceAsStream(resourcePath);
-            if (is == null) {
-                // Dev fallback: allow a manually placed library on java.library.path.
-                try {
-                    System.loadLibrary(libName);
-                    sLoaded = true;
-                    return;
-                } catch (UnsatisfiedLinkError e) {
-                    throw new FileNotFoundException("Native library not found in resources: "
-                            + resourcePath + " (and loadLibrary failed: " + e.getMessage() + ")");
-                }
-            }
-
-            File tempLib = File.createTempFile(prefix + libName + "_", extension);
-            tempLib.deleteOnExit();
-            Files.copy(is, tempLib.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            is.close();
-
-            System.load(tempLib.getAbsolutePath());
+            findAndLoad();
             sLoaded = true;
         } catch (Throwable e) {
             // Throwable, not Exception: System.load throws UnsatisfiedLinkError (an Error).
-            throw new RuntimeException("Failed to load native library 'filament-c': " + e, e);
+            throw new RuntimeException("Failed to load native library '" + LIB_NAME + "': " + e, e);
+        }
+    }
+
+    private static void findAndLoad() throws Exception {
+        String libFileName = platformLibFileName();
+
+        // First try: explicit directory override.
+        String libraryPath = System.getProperty("filament.library.path");
+        if (libraryPath != null) {
+            loadOrCopy(new File(libraryPath, libFileName));
+            return;
+        }
+
+        String resourcePath = "/natives/" + platformArch() + "/" + libFileName;
+        if (FilamentLoader.class.getResource(resourcePath) == null) {
+            // Dev fallback: allow a manually placed library on java.library.path.
+            try {
+                System.loadLibrary(LIB_NAME);
+                return;
+            } catch (UnsatisfiedLinkError e) {
+                throw new FileNotFoundException("Native library not found in resources: "
+                        + resourcePath + " (and loadLibrary failed: " + e.getMessage() + ")");
+            }
+        }
+
+        // Second try: extract-once into a cache dir keyed by the library's content hash,
+        // so a rebuilt lib (new hash) never collides with a cached one.
+        File cacheRoot = new File(System.getProperty("filament.data.path",
+                System.getProperty("user.home") + File.separator + ".filament-kmp"));
+        String hash = resourceHash(resourcePath);
+        File libDir = new File(cacheRoot, LIB_NAME + "-" + hash);
+        File lib = extractIfNeeded(cacheRoot, libDir, libFileName, () -> resourceStream(resourcePath));
+        libDir.setLastModified(System.currentTimeMillis()); // mark used, for cleanup
+        loadOrCopy(lib);
+        cleanupStaleCaches(cacheRoot, libDir);
+    }
+
+    private static String platformArch() {
+        String os = System.getProperty("os.name").toLowerCase();
+        String arch = System.getProperty("os.arch").toLowerCase();
+        String platform;
+        if (os.contains("win")) {
+            platform = "windows";
+        } else if (os.contains("mac") || os.contains("darwin")) {
+            platform = "macos";
+        } else if (os.contains("nux") || os.contains("nix") || os.contains("aix")) {
+            platform = "linux";
+        } else {
+            throw new UnsupportedOperationException("Unsupported OS: " + os);
+        }
+        String archDir = (arch.contains("aarch64") || arch.contains("arm64")) ? "arm64" : "x64";
+        return platform + "-" + archDir;
+    }
+
+    private static String platformLibFileName() {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) return LIB_NAME + ".dll";
+        if (os.contains("mac") || os.contains("darwin")) return "lib" + LIB_NAME + ".dylib";
+        return "lib" + LIB_NAME + ".so";
+    }
+
+    private static InputStream resourceStream(String resourcePath) {
+        InputStream is = FilamentLoader.class.getResourceAsStream(resourcePath);
+        if (is == null) throw new IllegalStateException("Resource vanished: " + resourcePath);
+        return is;
+    }
+
+    /**
+     * Cache key for the packaged library: the build stamps a {@code <lib>.sha256} resource
+     * next to it; if absent (repackaged jar), hash the resource stream at runtime.
+     */
+    private static String resourceHash(String resourcePath) throws Exception {
+        try (InputStream stamp = FilamentLoader.class.getResourceAsStream(resourcePath + ".sha256")) {
+            if (stamp != null) {
+                return new String(stamp.readAllBytes()).trim().substring(0, 16);
+            }
+        }
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        try (InputStream is = resourceStream(resourcePath)) {
+            byte[] buf = new byte[64 * 1024];
+            int n;
+            while ((n = is.read(buf)) >= 0) md.update(buf, 0, n);
+        }
+        return HexFormat.of().formatHex(md.digest()).substring(0, 16);
+    }
+
+    private static final Object EXTRACT_LOCK = new Object();
+
+    /**
+     * Extracts {@code libFileName} into {@code libDir} unless already present. Concurrent
+     * JVMs are serialized by a lock file in {@code cacheRoot} (in-process threads by a
+     * monitor — overlapping FileLocks in one JVM throw instead of blocking); the write goes
+     * through a temp file + atomic move so readers never observe a partial library.
+     */
+    static File extractIfNeeded(File cacheRoot, File libDir, String libFileName,
+                                Supplier<InputStream> content) throws IOException {
+        File lib = new File(libDir, libFileName);
+        if (lib.isFile()) return lib;
+        if (!libDir.isDirectory() && !libDir.mkdirs() && !libDir.isDirectory()) {
+            throw new IOException("Cannot create cache dir: " + libDir);
+        }
+        File lockFile = new File(cacheRoot, ".lock");
+        synchronized (EXTRACT_LOCK) {
+            try (RandomAccessFile raf = new RandomAccessFile(lockFile, "rw");
+                 FileLock ignored = raf.getChannel().lock()) {
+                if (lib.isFile()) return lib; // another process extracted while we waited
+                File tmp = File.createTempFile(LIB_NAME, ".tmp", libDir);
+                try (InputStream is = content.get()) {
+                    Files.copy(is, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
+                try {
+                    Files.move(tmp.toPath(), lib.toPath(),
+                            StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                } catch (AtomicMoveNotSupportedException e) {
+                    Files.move(tmp.toPath(), lib.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+        return lib;
+    }
+
+    /**
+     * A native image can only be loaded by one classloader per JVM; on the classic
+     * "already loaded in another classloader" error (e.g. two IDE plugins), load a
+     * private temp copy instead.
+     */
+    private static void loadOrCopy(File lib) throws IOException {
+        try {
+            System.load(lib.getAbsolutePath());
+        } catch (UnsatisfiedLinkError e) {
+            String msg = e.getMessage();
+            if (msg == null || !msg.contains("already loaded in another classloader")) throw e;
+            File copyDir = Files.createTempDirectory("filament").toFile();
+            File copy = new File(copyDir, lib.getName());
+            Files.copy(lib.toPath(), copy.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            copy.deleteOnExit();
+            copyDir.deleteOnExit();
+            System.load(copy.getAbsolutePath());
+        }
+    }
+
+    /** Best-effort purge of cache dirs from older builds that haven't been used recently. */
+    static void cleanupStaleCaches(File cacheRoot, File currentLibDir) {
+        int days = Integer.getInteger("filament.data.cleanup.days", 30);
+        if (days <= 0) return;
+        long cutoff = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days);
+        File[] dirs = cacheRoot.listFiles(f ->
+                f.isDirectory() && f.getName().startsWith(LIB_NAME + "-") && !f.equals(currentLibDir));
+        if (dirs == null) return;
+        for (File dir : dirs) {
+            if (dir.lastModified() >= cutoff) continue;
+            File[] files = dir.listFiles();
+            if (files != null) for (File f : files) f.delete(); // flat layout; ignore failures
+            dir.delete();
         }
     }
 }

--- a/java/src/test/java/io/github/erkko68/filament/ffm/FilamentLoaderTest.java
+++ b/java/src/test/java/io/github/erkko68/filament/ffm/FilamentLoaderTest.java
@@ -1,0 +1,121 @@
+package io.github.erkko68.filament.ffm;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Extraction-cache and cleanup behavior of {@link FilamentLoader} (no native loading). */
+public class FilamentLoaderTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private static Supplier<InputStream> content(String s) {
+        return () -> new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void extractsOnceAndReuses() throws Exception {
+        File cacheRoot = tmp.newFolder("cache");
+        File libDir = new File(cacheRoot, "filament-c-abc123");
+
+        File lib = FilamentLoader.extractIfNeeded(cacheRoot, libDir, "libfilament-c.dylib", content("v1"));
+        assertTrue(lib.isFile());
+        assertEquals("v1", Files.readString(lib.toPath()));
+
+        // Second call must not re-extract — new content is ignored because the file exists.
+        File again = FilamentLoader.extractIfNeeded(cacheRoot, libDir, "libfilament-c.dylib", content("v2"));
+        assertEquals(lib, again);
+        assertEquals("v1", Files.readString(again.toPath()));
+    }
+
+    @Test
+    public void noPartialFileLeftBehind() throws Exception {
+        File cacheRoot = tmp.newFolder("cache");
+        File libDir = new File(cacheRoot, "filament-c-abc123");
+        FilamentLoader.extractIfNeeded(cacheRoot, libDir, "lib.so", content("data"));
+
+        // Only the lib itself remains; the temp file was atomically moved away.
+        String[] files = libDir.list();
+        assertEquals(1, files == null ? 0 : files.length);
+        assertEquals("lib.so", files[0]);
+    }
+
+    @Test
+    public void concurrentExtractionYieldsOneConsistentFile() throws Exception {
+        File cacheRoot = tmp.newFolder("cache");
+        File libDir = new File(cacheRoot, "filament-c-abc123");
+        int threads = 8;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            var futures = new java.util.ArrayList<Future<File>>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    return FilamentLoader.extractIfNeeded(cacheRoot, libDir, "lib.so", content("payload"));
+                }));
+            }
+            start.countDown();
+            for (Future<File> f : futures) {
+                assertEquals("payload", Files.readString(f.get(30, TimeUnit.SECONDS).toPath()));
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    public void cleanupPurgesOldDirsKeepsRecentAndCurrent() throws Exception {
+        File cacheRoot = tmp.newFolder("cache");
+        File current = mkLibDir(cacheRoot, "filament-c-current", 40);
+        File stale = mkLibDir(cacheRoot, "filament-c-stale", 40);
+        File recent = mkLibDir(cacheRoot, "filament-c-recent", 1);
+        File unrelated = mkLibDir(cacheRoot, "other-dir", 40);
+
+        FilamentLoader.cleanupStaleCaches(cacheRoot, current);
+
+        assertTrue("current build's dir must survive", current.isDirectory());
+        assertFalse("40-day-old dir must be purged", stale.exists());
+        assertTrue("recently used dir must survive", recent.isDirectory());
+        assertTrue("non-cache dirs must be untouched", unrelated.isDirectory());
+    }
+
+    @Test
+    public void cleanupDisabledByProperty() throws Exception {
+        File cacheRoot = tmp.newFolder("cache");
+        File current = mkLibDir(cacheRoot, "filament-c-current", 40);
+        File stale = mkLibDir(cacheRoot, "filament-c-stale", 40);
+        System.setProperty("filament.data.cleanup.days", "0");
+        try {
+            FilamentLoader.cleanupStaleCaches(cacheRoot, current);
+            assertTrue(stale.isDirectory());
+        } finally {
+            System.clearProperty("filament.data.cleanup.days");
+        }
+    }
+
+    private static File mkLibDir(File root, String name, int ageDays) throws Exception {
+        File dir = new File(root, name);
+        assertTrue(dir.mkdirs());
+        Files.writeString(new File(dir, "lib.so").toPath(), "x");
+        assertTrue(dir.setLastModified(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ageDays)));
+        return dir;
+    }
+}


### PR DESCRIPTION
Adopts the native-runtime best practices from [JetBrains/skiko](https://github.com/jetbrains/skiko) that apply to this project (per the repo review; the per-platform runtime-jar split follows in a separate PR).

## Native loader rework
`FilamentLoader` previously re-extracted the 18 MB `libfilament-c` to a fresh temp file on **every JVM start**, relying on `deleteOnExit` (which silently fails on Windows — the loaded DLL stays held, littering the temp dir), and failed outright when two classloaders loaded the bindings.

It now follows Skiko's `LibraryLoader` pattern:
- extracted **once** into a content-hash-keyed cache dir `~/.filament-kmp/filament-c-<hash>/`, reused across JVM starts (the build stamps a `.sha256` next to each packaged native; runtime falls back to stream-hashing if the stamp is missing)
- concurrent processes serialized by a lock file, in-process threads by a monitor; temp-file + atomic move so readers never see a partial lib
- `filament.library.path` (load from a directory, no extraction), `filament.data.path` (cache root), `filament.data.cleanup.days` (stale purge, default 30, `<= 0` disables)
- "already loaded in another classloader" → loads a private temp copy (IDE-plugin scenario)

Unit tests cover extraction reuse, atomicity, concurrency, and cleanup; `:java:test` runs in the CI jvm matrix.

## Symbol sealing (macOS/Linux)
The combined shared lib exported 3,280 symbols — filament's own C++ internals (`filament::`, `filamat::`, `utils::`) leaked into the process-wide namespace. Now only the 872 `Fila*` C symbols are exported, via `-Wl,-exported_symbol,_Fila*` (macOS) and a version script `c/filament-c.map` (Linux). Windows stays on `WINDOWS_EXPORT_ALL_SYMBOLS`: DLL imports bind by (module, name), so surplus exports can't be interposed.

## Build overrides
- `-Pfilament.debug=true` → `CMAKE_BUILD_TYPE=Debug` for the C wrapper (JVM + Kotlin/Native helpers). Prebuilts stay Release; Windows Debug won't link against the `/MT` prebuilts (documented).
- `FILAMENT_PREBUILTS_DIR=<dir>` (env) → link against a locally built Filament (`<dir>/<target>/lib`, mirroring `prebuilts/`) and skip the download task — the workflow needed for custom engine patches.

## Verification
- Loader unit tests + all five `:kotlin:*:jvmTest` suites green, loading the sealed lib through the new cache path end-to-end; second run confirmed no re-extraction.
- `nm -gU`: 3280 → 872 exports, all `Fila*`.
- `CMAKE_BUILD_TYPE` verified flipping Debug/Release; `FILAMENT_LIB_DIR` verified honoring the env override; iOS wrapper cmake build green after the helper change.