### PR TITLE
feat(jvm): split filament-ffm into bindings + per-platform native runtime jars

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,6 +132,10 @@ jobs:
             -PlibVersion=${{ steps.version.outputs.version }} \
             -PcArtifactsDir=${{ github.workspace }}/c-artifacts \
             :java:publishAllPublicationsToMavenCentralRepository \
+            :java:runtime-macos-arm64:publishAllPublicationsToMavenCentralRepository \
+            :java:runtime-linux-x64:publishAllPublicationsToMavenCentralRepository \
+            :java:runtime-linux-arm64:publishAllPublicationsToMavenCentralRepository \
+            :java:runtime-windows-x64:publishAllPublicationsToMavenCentralRepository \
             :kotlin:filament:publishAllPublicationsToMavenCentralRepository \
             :kotlin:filamat:publishAllPublicationsToMavenCentralRepository \
             :kotlin:filament-utils:publishAllPublicationsToMavenCentralRepository \

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![JVM](https://github.com/Erkko68/filament-kmp/actions/workflows/status-jvm.yml/badge.svg?branch=main)](https://github.com/Erkko68/filament-kmp/actions/workflows/status-jvm.yml)
 [![JS](https://github.com/Erkko68/filament-kmp/actions/workflows/status-js.yml/badge.svg?branch=main)](https://github.com/Erkko68/filament-kmp/actions/workflows/status-js.yml)
+[![Wasm](https://github.com/Erkko68/filament-kmp/actions/workflows/status-wasm.yml/badge.svg?branch=main)](https://github.com/Erkko68/filament-kmp/actions/workflows/status-wasm.yml)
 [![iOS](https://github.com/Erkko68/filament-kmp/actions/workflows/status-ios.yml/badge.svg?branch=main)](https://github.com/Erkko68/filament-kmp/actions/workflows/status-ios.yml)
 [![Android](https://github.com/Erkko68/filament-kmp/actions/workflows/status-android.yml/badge.svg?branch=main)](https://github.com/Erkko68/filament-kmp/actions/workflows/status-android.yml)
 
@@ -15,9 +16,9 @@
 > **Unofficial project.** This is a community-maintained Kotlin Multiplatform wrapper around [Google's Filament](https://github.com/google/filament). It is not affiliated with, endorsed by, or supported by Google or the Filament team.
 
 > [!WARNING]
-> **Pre-release (`0.1.3-beta`).** This is pre-1.0 software and public APIs may still change between releases — the JVM bindings were just rebuilt on Project Panama (FFM, **requires JDK 22+**) and the Web bindings on Karakum. Pin a specific version and read the [release notes](https://github.com/Erkko68/filament-kmp/releases) before upgrading.
+> **Pre-release (`0.1.3-beta`).** This is pre-1.0 software and public APIs may still change between releases — the JVM bindings run on Project Panama (FFM, **requires JDK 22+**). Pin a specific version and read the [release notes](https://github.com/Erkko68/filament-kmp/releases) before upgrading.
 
-**Filament KMP** brings the same physically based renderer that powers Android's Filament to **iOS**, **Desktop/JVM**, and **Web/JS**, with first-class **Compose Multiplatform** integration.
+**Filament KMP** brings the same physically based renderer that powers Android's Filament to **iOS**, **Desktop/JVM**, and **Web (JS & Wasm)**, with first-class **Compose Multiplatform** integration.
 
 <img src="docs/images/platforms-hero.png" alt="The same scene rendering on Android, iOS, Desktop and Web" width="800"/>
 
@@ -40,7 +41,7 @@ The world is declared in the content lambda; the viewport's look is configured b
 - **Android** — OpenGL ES / Vulkan via the official `com.google.android.filament` library
 - **iOS** — Metal via C wrapper + Kotlin/Native cinterop
 - **Desktop / JVM** (macOS, Windows, Linux) — Metal / Vulkan / OpenGL via Project Panama (FFM) bindings over a combined C wrapper
-- **Web / JS** — WebGL 2.0 via Filament.js, with Kotlin externals generated from `filament.d.ts`
+- **Web (JS & Wasm)** — WebGL 2.0 via Filament.js (embind), through hand-maintained Kotlin externals shared by the `js` and `wasmJs` targets
 
 **JVM requirements:** the Android artifacts ship JVM 11 bytecode (minSdk 24) and work with the standard Android `jvmTarget = 11` setup. The Desktop/JVM artifacts require **JDK 22+** at build and run time — the FFM bindings call `java.lang.foreign`, finalized in JDK 22.
 
@@ -81,7 +82,7 @@ For the full setup (Compose Multiplatform plugin, FFM native runtime for Desktop
 | `filamat` | Runtime material compilation — `MaterialBuilder`. |
 | `filament-utils` | Camera manipulators, HDR/KTX loaders, math helpers. |
 
-All published under `io.github.erkko68.filament`. The Desktop/JVM native runtime (Project Panama / FFM) ships as `io.github.erkko68.filament-ffm:filament-ffm` and is pulled in automatically. See **[Modules](docs/modules.md)** for full coordinates and dependency graph.
+All published under `io.github.erkko68.filament`. The Desktop/JVM bindings (Project Panama / FFM) ship as `io.github.erkko68.filament-ffm:filament-ffm` and are pulled in automatically, with the natives in per-platform `filament-ffm-runtime-<os>-<arch>` jars — all of them by default, or only your platform's if your build declares os/arch attributes (see [java/README.md](java/README.md)). See **[Modules](docs/modules.md)** for full coordinates and dependency graph.
 
 ## API strategy
 

--- a/buildSrc/src/main/kotlin/FfmRuntimePlatforms.kt
+++ b/buildSrc/src/main/kotlin/FfmRuntimePlatforms.kt
@@ -1,0 +1,24 @@
+/**
+ * The FFM native runtime platform set, shared between :java (which stages the natives and
+ * exposes them via consumable configurations) and the :java:runtime* modules (which jar and
+ * publish them).
+ *
+ * `published` mirrors the CI publish matrix (.github/workflows/publish.yml build-natives).
+ * A dev host outside that list (e.g. macos-x64) still gets a staging config so the fat
+ * :java:runtime jar works locally — it just has no dedicated runtime-<platform> module.
+ */
+object FfmRuntimePlatforms {
+    val published = listOf("macos-arm64", "linux-x64", "linux-arm64", "windows-x64")
+
+    /** "{platform}-{arch}" of the build host, matching FilamentJvmNative's resource layout. */
+    fun host(): String {
+        val arch = if (hostArch() == "Arm64") "arm64" else "x64"
+        return "${hostPlatform()}-$arch"
+    }
+
+    /** published + host, host first so local staging always exists. */
+    fun all(): List<String> = (listOf(host()) + published).distinct()
+
+    /** Name of :java's consumable configuration carrying the staged natives dir. */
+    fun nativesConfigName(platformArch: String) = "ffmNatives-$platformArch"
+}

--- a/buildSrc/src/main/kotlin/filament-ffm-runtime-platform.gradle.kts
+++ b/buildSrc/src/main/kotlin/filament-ffm-runtime-platform.gradle.kts
@@ -1,0 +1,53 @@
+// Convention for the per-platform FFM native runtime modules (:java:runtime-<platform>-<arch>).
+// Each publishes a resources-only jar with natives/<platform>-<arch>/libfilament-c.* (+ .sha256),
+// staged by :java (host: local cmake build; other platforms: -PcArtifactsDir on CI).
+// The project name encodes the platform: "runtime-macos-arm64" → "macos-arm64".
+
+import java.util.zip.ZipFile
+
+plugins {
+    `java-library`
+    id("filament-publish")
+}
+
+val platformArch = project.name.removePrefix("runtime-")
+
+// The published natives are JDK-agnostic resources, but the module's GMM variants carry a
+// jvm-version attribute derived from targetCompatibility — pin it to the FFM floor (22) so
+// consumers on JDK 22 toolchains aren't rejected by attribute matching.
+java {
+    sourceCompatibility = JavaVersion.VERSION_22
+    targetCompatibility = JavaVersion.VERSION_22
+}
+
+val ffmNativesInput = configurations.create("ffmNativesInput") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+dependencies {
+    // Standalone usability: adding just this runtime module pulls the matching bindings.
+    api(project(":java"))
+    ffmNativesInput(project(mapOf("path" to ":java", "configuration" to FfmRuntimePlatforms.nativesConfigName(platformArch))))
+}
+
+tasks.named<Jar>("jar") {
+    // The staged dir already has the natives/<platform>-<arch>/ layout FilamentLoader expects.
+    from(ffmNativesInput)
+}
+
+// Off-host platforms stage nothing without -PcArtifactsDir (CI publish job), producing an
+// empty jar — fine for a local `build`, silently broken on Maven Central. Fail the publish.
+val jarFile = tasks.named<Jar>("jar").flatMap { it.archiveFile }
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    val archive = jarFile
+    val pa = platformArch
+    doFirst {
+        ZipFile(archive.get().asFile).use { zip ->
+            check(zip.entries().asIterator().asSequence().any { it.name.startsWith("natives/$pa/") && !it.isDirectory }) {
+                "Refusing to publish an empty $pa runtime jar — natives were not staged " +
+                    "(CI passes -PcArtifactsDir; this platform's libfilament-c is missing)."
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/filament-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/filament-publish.gradle.kts
@@ -1,3 +1,4 @@
+import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.KotlinMultiplatform
@@ -24,6 +25,9 @@ mavenPublishing {
             configure(KotlinMultiplatform(javadocJar = JavadocJar.Empty()))
         pluginManager.hasPlugin("org.jetbrains.kotlin.jvm") ->
             configure(KotlinJvm(javadocJar = JavadocJar.Empty(), sourcesJar = true))
+        // Plain resource jars (the :java:runtime* native-runtime modules).
+        pluginManager.hasPlugin("java-library") ->
+            configure(JavaLibrary(javadocJar = JavadocJar.Empty(), sourcesJar = true))
     }
 
     pom {

--- a/java/README.md
+++ b/java/README.md
@@ -55,10 +55,35 @@ Build knobs:
 - **JDK 22+** at runtime (the FFM API floor). Compilation targets `--release 22`; the
   Gradle daemon itself runs on a newer JDK.
 
-## Publishing
+## Publishing — artifact set (skiko-awt-runtime style)
 
-CI's [`publish.yml`](../.github/workflows/publish.yml) builds `libfilament-c` on each
-platform runner, then publishes this module with `-PcArtifactsDir=<dir>` (one
-`<platform>-<arch>/` subdir per platform) so the released JAR bundles natives for every
-supported platform. The artifact id is pinned to `filament-ffm` in `build.gradle.kts`
-(the project directory is `java/`, but the published id is not).
+The bindings and the natives are published separately (artifact ids pinned via
+`maven.artifactId` in each module's `gradle.properties`):
+
+| Artifact | Contents |
+|---|---|
+| `filament-ffm` | jextract bindings + loader + FFM helpers — **no natives**. By default its runtime metadata depends on **all** platform modules below; its Gradle-metadata variants (`OperatingSystemFamily` × `MachineArchitecture`) narrow that to exactly one |
+| `filament-ffm-runtime-{macos-arm64, linux-x64, linux-arm64, windows-x64}` | one platform's `libfilament-c` (+ `.sha256`) |
+
+The `:kotlin:*` JVM targets depend on `filament-ffm` alone, so plain consumers keep
+working with zero configuration — they pull every platform's natives, as before the
+split. Gradle consumers who only want their platform's ~18 MB add two attributes and the
+per-platform variant is selected automatically:
+
+```kotlin
+configurations.matching { it.isCanBeResolved }.configureEach {
+    attributes {
+        attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(OperatingSystemFamily.MACOS))
+        attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(MachineArchitecture.ARM64))
+    }
+}
+```
+
+Maven (non-Gradle) consumers get the per-platform modules through `filament-ffm`'s POM.
+
+The platform set mirrors upstream Filament's prebuilt releases (no windows-arm64: Google
+doesn't publish one; Windows-on-ARM works via the x64 JVM emulation path). CI's
+[`publish.yml`](../.github/workflows/publish.yml) builds `libfilament-c` on each platform
+runner and publishes with `-PcArtifactsDir=<dir>` (one `<platform>-<arch>/` subdir per
+platform); `:java` stages the natives per platform and the `:java:runtime*` modules jar
+them. Publishing fails fast if a runtime jar would ship without its natives.

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -1,4 +1,8 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.gradle.api.attributes.java.TargetJvmEnvironment
+import org.gradle.api.attributes.java.TargetJvmVersion
+import org.gradle.nativeplatform.MachineArchitecture
+import org.gradle.nativeplatform.OperatingSystemFamily
 import java.security.MessageDigest
 
 plugins {
@@ -63,55 +67,175 @@ sourceSets.named("main") {
     java.srcDir(ffm.jextract)
 }
 
-// ── Package the combined dylib into resources (mirrors java/filament) ─────────
-tasks.named<ProcessResources>("processResources") {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    dependsOn(ffm.cmakeBuild)
-    val platformArch = ffm.platformArch
-    // Single-config generators (Make / Ninja) put libs directly in build/cmake/.
-    from(ffm.dylibDir) {
-        include("*.dylib", "*.so", "*.dll")
-        into("natives/$platformArch")
-    }
-    // Multi-config generators (Visual Studio) put DLLs in build/cmake/<config>/.
-    from(ffm.dylibDir.map { it.dir(ffm.buildType) }) {
-        include("*.dll")
-        into("natives/$platformArch")
-    }
-    // Bundle pre-compiled natives from other platforms (CI publish job). Pass
-    // -PcArtifactsDir=<path> where the dir has {platform}-{arch}/ subdirs each
-    // containing the combined libfilament-c for that platform.
-    val cArtifactsDir = (project.findProperty("cArtifactsDir") as? String)?.let { file(it) }
-    if (cArtifactsDir != null && cArtifactsDir.exists()) {
-        cArtifactsDir.listFiles { f -> f.isDirectory }?.forEach { platformDir ->
-            from(platformDir) {
+// ── Stage the natives per platform (consumed by the :java:runtime* modules) ───
+//
+// The natives no longer ship inside this module's jar: each platform's
+// libfilament-c (+ .sha256 stamp — FilamentLoader keys its extraction cache dir by it)
+// is staged into build/ffm-natives/<platform-arch>/natives/<platform-arch>/ and exposed
+// through a consumable `ffmNatives-<platform-arch>` configuration. :java:runtime-<pa>
+// jars one platform; :java:runtime jars them all (fat fallback).
+//
+// Sources: the host platform comes from the local cmake build; other platforms from
+// -PcArtifactsDir=<path> (CI publish job), whose {platform}-{arch}/ subdirs each hold the
+// combined libfilament-c for that platform. The host may appear in both — local wins.
+val cArtifactsDir = (project.findProperty("cArtifactsDir") as? String)?.let { file(it) }
+FfmRuntimePlatforms.all().forEach { pa ->
+    val stage = tasks.register<Sync>("stageFfmNatives_$pa") {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        into(layout.buildDirectory.dir("ffm-natives/$pa"))
+        if (pa == ffm.platformArch) {
+            dependsOn(ffm.cmakeBuild)
+            // Single-config generators (Make / Ninja) put libs directly in build/cmake/;
+            // multi-config ones (Visual Studio) in build/cmake/<config>/.
+            from(ffm.dylibDir) {
                 include("*.dylib", "*.so", "*.dll")
-                into("natives/${platformDir.name}")
+                into("natives/$pa")
+            }
+            from(ffm.dylibDir.map { it.dir(ffm.buildType) }) {
+                include("*.dll")
+                into("natives/$pa")
             }
         }
-    }
-    // Stamp each native with its sha256 — FilamentLoader keys its extraction cache dir by it.
-    doLast {
-        val md = MessageDigest.getInstance("SHA-256")
-        destinationDir.resolve("natives").walkTopDown()
-            .filter { it.isFile && it.extension in setOf("dylib", "so", "dll") }
-            .forEach { lib ->
-                md.reset()
-                lib.inputStream().use { ins ->
-                    val buf = ByteArray(64 * 1024)
-                    while (true) {
-                        val n = ins.read(buf)
-                        if (n < 0) break
-                        md.update(buf, 0, n)
-                    }
-                }
-                File(lib.path + ".sha256").writeText(md.digest().joinToString("") { "%02x".format(it) })
+        if (cArtifactsDir != null) {
+            from(File(cArtifactsDir, pa)) {
+                include("*.dylib", "*.so", "*.dll")
+                into("natives/$pa")
             }
+        }
+        doLast {
+            val md = MessageDigest.getInstance("SHA-256")
+            destinationDir.walkTopDown()
+                .filter { it.isFile && it.extension in setOf("dylib", "so", "dll") }
+                .forEach { lib ->
+                    md.reset()
+                    lib.inputStream().use { ins ->
+                        val buf = ByteArray(64 * 1024)
+                        while (true) {
+                            val n = ins.read(buf)
+                            if (n < 0) break
+                            md.update(buf, 0, n)
+                        }
+                    }
+                    File(lib.path + ".sha256").writeText(md.digest().joinToString("") { "%02x".format(it) })
+                }
+        }
+    }
+    val cfg = configurations.create(FfmRuntimePlatforms.nativesConfigName(pa)) {
+        isCanBeConsumed = true
+        isCanBeResolved = false
+    }
+    artifacts.add(cfg.name, layout.buildDirectory.dir("ffm-natives/$pa")) {
+        builtBy(stage)
     }
 }
 
 tasks.named("assemble") {
     dependsOn(ffm.cmakeBuild)
+}
+
+// ── Native runtime resolution (published on this module's own metadata) ───────
+//
+// Default (plain Gradle or Maven, no attributes): the runtime variant depends on every
+// :java:runtime-<platform>-<arch> jar — zero-config, all platforms, as before the split.
+// Gradle consumers that declare OperatingSystemFamily + MachineArchitecture attributes
+// match one of the extra variants below instead and download a single platform's ~18 MB.
+
+// Bucket for the all-platforms default. Kept out of implementation/runtimeOnly so the
+// attributed variants (which extend those) don't inherit every platform.
+val ffmRuntimeAll = configurations.create("ffmRuntimeAll") {
+    isCanBeConsumed = false
+    isCanBeResolved = false
+}
+configurations.named("runtimeElements") { extendsFrom(ffmRuntimeAll) }
+dependencies {
+    FfmRuntimePlatforms.published.forEach { pa ->
+        ffmRuntimeAll(project(":java:runtime-$pa"))
+    }
+}
+
+// A dev host outside the published set (e.g. macos-x64) has no platform module; bundle its
+// locally staged natives into this jar so project-dependency consumers (jvmTest, samples)
+// still run. On published platforms the jar stays natives-free. CI publishes from a
+// published platform, so this never leaks into a release.
+val hostPa = FfmRuntimePlatforms.host()
+if (hostPa !in FfmRuntimePlatforms.published) {
+    val hostNatives = configurations.create("ffmHostNativesInput") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+    dependencies {
+        hostNatives(project(mapOf("path" to path, "configuration" to FfmRuntimePlatforms.nativesConfigName(hostPa))))
+    }
+    tasks.named<Jar>("jar") {
+        from(hostNatives)
+    }
+}
+
+// The attributed variants must mirror everything runtimeElements offers (the bindings jar,
+// kotlin-stdlib, …) because Gradle selects them INSTEAD of runtimeElements — hence the
+// extendsFrom of the declaring buckets, plus the one platform dep that replaces ffmRuntimeAll.
+val javaComponent = components["java"] as AdhocComponentWithVariants
+FfmRuntimePlatforms.published.forEach { pa ->
+    val osFamily = when (pa.substringBeforeLast('-')) {
+        "macos" -> OperatingSystemFamily.MACOS
+        "linux" -> OperatingSystemFamily.LINUX
+        "windows" -> OperatingSystemFamily.WINDOWS
+        else -> error("Unknown platform in '$pa'")
+    }
+    val machineArch = when (pa.substringAfterLast('-')) {
+        "arm64" -> MachineArchitecture.ARM64
+        "x64" -> MachineArchitecture.X86_64
+        else -> error("Unknown arch in '$pa'")
+    }
+    val variant = configurations.create("ffmRuntime-$pa") {
+        isCanBeConsumed = true
+        isCanBeResolved = false
+        extendsFrom(configurations["implementation"], configurations["runtimeOnly"])
+        attributes {
+            attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(osFamily))
+            attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(machineArch))
+        }
+    }
+    dependencies.add(variant.name, project(":java:runtime-$pa"))
+    artifacts.add(variant.name, tasks.named("jar"))
+    javaComponent.addVariantsFromConfiguration(variant) { mapToMavenScope("runtime") }
+}
+
+// Each variant's attributes must be runtimeElements' full set + os/arch, and nothing less:
+// plain consumers then disambiguate to runtimeElements (the strict-subset candidate), while
+// attributed consumers match os/arch and get the platform variant. Hand-listing runs behind
+// what the kotlin plugin stamps on runtimeElements (e.g. kotlin.platform.type), so copy.
+afterEvaluate {
+    val source = configurations["runtimeElements"].attributes
+    configurations.matching { it.name.startsWith("ffmRuntime-") }.configureEach {
+        source.keySet().forEach { key ->
+            @Suppress("UNCHECKED_CAST")
+            val k = key as Attribute<Any>
+            if (attributes.getAttribute(k) == null) {
+                attributes.attribute(k, source.getAttribute(k)!!)
+            }
+        }
+    }
+}
+
+// Each platform dep reaches the POM twice — once from ffmRuntimeAll via runtimeElements,
+// once from its variant's maven-scope mapping. Dedupe by artifactId; GMM is unaffected.
+publishing {
+    publications.withType<MavenPublication>().configureEach {
+        pom.withXml {
+            val deps = asElement().getElementsByTagName("dependency")
+            val seen = mutableSetOf<String>()
+            val doomed = (0 until deps.length).map { deps.item(it) }.filter { node ->
+                val children = node.childNodes
+                val artifactId = (0 until children.length)
+                    .map { children.item(it) }
+                    .firstOrNull { it.nodeName == "artifactId" }
+                    ?.textContent ?: return@filter false
+                !seen.add(artifactId)
+            }
+            doomed.forEach { it.parentNode.removeChild(it) }
+        }
+    }
 }
 
 // ── Loader unit tests (extraction cache + stale-dir cleanup) ──────────────────

--- a/java/runtime-linux-arm64/build.gradle.kts
+++ b/java/runtime-linux-arm64/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("filament-ffm-runtime-platform")
+}

--- a/java/runtime-linux-arm64/gradle.properties
+++ b/java/runtime-linux-arm64/gradle.properties
@@ -1,0 +1,2 @@
+maven.artifactId=filament-ffm-runtime-linux-arm64
+maven.description=Filament KMP JVM native runtime for linux-arm64.

--- a/java/runtime-linux-x64/build.gradle.kts
+++ b/java/runtime-linux-x64/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("filament-ffm-runtime-platform")
+}

--- a/java/runtime-linux-x64/gradle.properties
+++ b/java/runtime-linux-x64/gradle.properties
@@ -1,0 +1,2 @@
+maven.artifactId=filament-ffm-runtime-linux-x64
+maven.description=Filament KMP JVM native runtime for linux-x64.

--- a/java/runtime-macos-arm64/build.gradle.kts
+++ b/java/runtime-macos-arm64/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("filament-ffm-runtime-platform")
+}

--- a/java/runtime-macos-arm64/gradle.properties
+++ b/java/runtime-macos-arm64/gradle.properties
@@ -1,0 +1,2 @@
+maven.artifactId=filament-ffm-runtime-macos-arm64
+maven.description=Filament KMP JVM native runtime for macos-arm64.

--- a/java/runtime-windows-x64/build.gradle.kts
+++ b/java/runtime-windows-x64/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("filament-ffm-runtime-platform")
+}

--- a/java/runtime-windows-x64/gradle.properties
+++ b/java/runtime-windows-x64/gradle.properties
@@ -1,0 +1,2 @@
+maven.artifactId=filament-ffm-runtime-windows-x64
+maven.description=Filament KMP JVM native runtime for windows-x64.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,7 +34,16 @@ include(":kotlin:test-support") // test-only shared helpers (TestEnv + skip anno
 // JVM/Panama (FFM) bindings: one combined libfilament-c image (filament + filamat +
 // filament-utils + gltfio) plus jextract-generated bindings. All four kotlin JVM modules
 // depend on it; it replaced the per-module hand-written JNI stack (java/filament*, java/gltfio).
-// Published as the `filament-ffm` artifact (id pinned in java/build.gradle.kts).
+// Published as the `filament-ffm` artifact (bindings only — natives live in the runtime
+// modules below; artifact ids pinned via maven.artifactId in each module's gradle.properties).
 include(":java")
+
+// FFM native runtime jars (skiko-awt-runtime style): one slim natives jar per platform.
+// filament-ffm's own metadata depends on all of them by default; its per-platform
+// Gradle-metadata variants (os/arch attributes) narrow that to exactly one.
+include(":java:runtime-macos-arm64")
+include(":java:runtime-linux-x64")
+include(":java:runtime-linux-arm64")
+include(":java:runtime-windows-x64")
 
 include(":web")


### PR DESCRIPTION
Stacked on #60 — merge that first; this PR then collapses to a single commit.

`filament-ffm` previously bundled all four platforms' natives (~18 MB each), so every consumer downloaded — and shipped — three platforms they never run on. This splits the natives into per-platform jars following the [skiko-awt-runtime](https://github.com/JetBrains/skiko) model, with the platform selection living on `filament-ffm`'s own Gradle metadata (no extra aggregator artifact, nothing published twice).

## Published artifact set

| Artifact | Contents |
|---|---|
| `filament-ffm` | bindings + loader — no natives. Default runtime variant depends on all four platform jars; Gradle-metadata variants keyed by `OperatingSystemFamily` × `MachineArchitecture` narrow that to one |
| `filament-ffm-runtime-{macos-arm64, linux-x64, linux-arm64, windows-x64}` | one platform's `libfilament-c` + `.sha256` |

No windows-arm64: upstream Filament publishes no such prebuilt (the windows tgz is x86_64-only). Windows-on-ARM runs the x64 JVM under emulation, where `os.arch` reports `amd64` and the loader picks the windows-x64 natives.

## Consumer behavior (verified against mavenLocal with a standalone consumer build)

- **Plain Gradle / Maven consumer**: resolves bindings + all four platform jars — zero-config, same bytes as before the split.
- **Consumer declaring the two os/arch attributes**: resolves bindings + exactly one platform jar (~18 MB). Snippet documented in `java/README.md`.

One subtlety worth knowing: the attributed variants copy `runtimeElements`' full attribute set in `afterEvaluate` before adding os/arch. Hand-listing the attributes broke plain consumers with an ambiguity error, because the kotlin-jvm plugin stamps extras (`kotlin.platform.type`) on `runtimeElements` — disambiguation only falls back to the default variant when its attributes are a strict subset of the variants'.

## Mechanics

- `:java` stages natives per platform (host from the local cmake build, other platforms from `-PcArtifactsDir` on CI) into consumable `ffmNatives-<platform>` configurations, with the loader-cache `.sha256` stamps generated at staging time.
- Four `:java:runtime-<platform>` modules jar the staged dirs via a shared convention plugin; each `api`-depends on `filament-ffm` for standalone use.
- A dev host outside the published set (e.g. macos-x64) gets its natives bundled into the `filament-ffm` jar as a local fallback so jvmTest/samples still run.
- Publish guards fail fast if a platform runtime jar would ship without its natives.
- The kotlin JVM targets keep their single `api(project(":java"))` dependency — no wiring changes for consumers.

Also refreshes the main README: drops the retired-Karakum mention, describes the web bindings as hand-maintained externals shared by `js`/`wasmJs`, adds the Wasm status badge, and documents the runtime-jar scheme.

## Verification

- Full JVM suite + `:java:test` green (configuration cache on); samples desktop app compiles via includeBuild substitution.
- `publishToMavenLocal` with a synthetic `cArtifactsDir`; GMM/POM inspected (deduped POM, variants carrying the bindings jar + stdlib + one platform dep).
- Standalone consumer resolved both paths (plain → all platforms, attributed → single platform).