### PR TITLE
docs: finish the KDoc migration sweep (gltfio, MaterialBuilder, View)

### DIFF
--- a/kotlin/filamat/src/commonMain/kotlin/io/github/erkko68/filament/filamat/MaterialBuilder.kt
+++ b/kotlin/filamat/src/commonMain/kotlin/io/github/erkko68/filament/filamat/MaterialBuilder.kt
@@ -146,121 +146,257 @@ expect class MaterialBuilder() {
         CUSTOM
     }
 
+    /** Coordinate space the vertex shader's `material()` output is expressed in. */
     enum class VertexDomain {
+        /** Vertices are in object/model space (default). */
         OBJECT,
+        /** Vertices are in world space; the object transform is ignored. */
         WORLD,
+        /** Vertices are in view/eye space. */
         VIEW,
+        /** Vertices are in normalized device space; view and object transforms are ignored. */
         DEVICE
     }
 
+    /** Which triangle faces are culled before rasterization. */
     enum class CullingMode {
+        /** No culling; both faces are rendered. */
         NONE,
+        /** Front faces are culled. */
         FRONT,
+        /** Back faces are culled (default). */
         BACK,
+        /** Both faces are culled; geometry-less rendering. */
         FRONT_AND_BACK
     }
 
+    /** How transparent objects are rendered ([BlendingMode.TRANSPARENT]/[BlendingMode.FADE] only). */
     enum class TransparencyMode {
+        /** Object is rendered in one pass; can self-overlap visibly (default). */
         DEFAULT,
+        /** Two passes: depth pre-pass then color; only the front-most surface shows. */
         TWO_PASSES_ONE_SIDE,
+        /** Two passes: back faces first, then front faces; approximates two-layer transparency. */
         TWO_PASSES_TWO_SIDES
     }
 
+    /** Which pipeline stage the material targets. */
     enum class MaterialDomain {
+        /** Regular surface shading in the scene (default). */
         SURFACE,
+        /** Full-screen post-processing effect. */
         POST_PROCESS
     }
 
+    /** How ambient occlusion is applied to specular indirect lighting. */
     enum class SpecularAmbientOcclusion {
+        /** AO does not affect specular lighting. */
         NONE,
+        /** Cheap approximation from the AO term (default on high quality). */
         SIMPLE,
+        /** Higher-quality occlusion using bent normals. */
         BENT_NORMALS
     }
 
+    /** Source of refracted light for refractive materials. */
     enum class RefractionMode {
+        /** No refraction (default). */
         NONE,
+        /** Refraction samples the IBL cubemap; cheap, world-independent. */
         CUBEMAP,
+        /** Refraction samples the opaque scene render; requires screen-space refraction on the View. */
         SCREEN_SPACE
     }
 
+    /** Source of reflections for the material. */
     enum class ReflectionMode {
+        /** Reflections come from the IBL/environment (default). */
         DEFAULT,
+        /** Reflections come from screen-space ray marching on the View. */
         SCREEN_SPACE
     }
 
+    /** Geometry model used to compute refraction. */
     enum class RefractionType {
+        /** Object is a solid volume (e.g. glass sphere); refraction bends twice (default). */
         SOLID,
+        /** Object is a thin shell (e.g. window pane, bubble); refraction bends once. */
         THIN
     }
 
+    /** Platform class to generate shaders for. */
     enum class Platform {
+        /** Desktop-class GPUs. */
         DESKTOP,
+        /** Mobile-class GPUs (default on device builds). */
         MOBILE,
+        /** Both desktop and mobile shader sets. */
         ALL
     }
 
+    /** Graphics API(s) to generate shaders for. */
     enum class TargetApi {
+        /** OpenGL / OpenGL ES (GLSL). */
         OPENGL,
+        /** Vulkan (SPIR-V). */
         VULKAN,
+        /** Metal (MSL). */
         METAL,
+        /** WebGPU (WGSL). */
         WEBGPU,
+        /** Every supported API; largest package. */
         ALL
     }
 
+    /** Shader optimization level applied at compile time. */
     enum class Optimization {
+        /** No optimization; fastest compile, best for debugging. */
         NONE,
+        /** Only run the preprocessor. */
         PREPROCESSOR,
+        /** Optimize for smallest shader size. */
         SIZE,
+        /** Optimize for runtime performance (default). */
         PERFORMANCE
     }
 
     companion object {
+        /** Initializes the material compiler's global state. Call once before building materials. */
         fun init()
+
+        /** Releases the material compiler's global state. Call when done building materials. */
         fun shutdown()
     }
 
+    /** Compiles the material and returns the resulting package (check `isValid` before use). */
     fun build(): MaterialPackage
+
+    /** Sets the material's name (shown in tooling and debug output). */
     fun name(name: String): MaterialBuilder
+
+    /** Sets the material domain ([MaterialDomain.SURFACE] by default). */
     fun materialDomain(domain: MaterialDomain): MaterialBuilder
+
+    /** Sets the shading model (LIT, UNLIT, SUBSURFACE, CLOTH, SPECULAR_GLOSSINESS). */
     fun shading(shading: Shading): MaterialBuilder
+
+    /** Sets the interpolation quality of the shading normal (default: SMOOTH). */
     fun interpolation(interpolation: Interpolation): MaterialBuilder
+
+    /** Declares a uniform parameter of [type] named [name], settable via `MaterialInstance.setParameter`. */
     fun uniformParameter(type: UniformType, name: String): MaterialBuilder
+
+    /** Declares a uniform parameter with an explicit shader [precision]. */
     fun uniformParameter(type: UniformType, precision: ParameterPrecision, name: String): MaterialBuilder
+
+    /** Declares a uniform array parameter of [size] elements. */
     fun uniformParameterArray(type: UniformType, size: Int, name: String): MaterialBuilder
+
+    /** Declares a uniform array parameter with an explicit shader [precision]. */
     fun uniformParameterArray(type: UniformType, size: Int, precision: ParameterPrecision, name: String): MaterialBuilder
+
+    /** Declares a texture sampler parameter, settable via `MaterialInstance.setParameter`. */
     fun samplerParameter(type: SamplerType, format: SamplerFormat, precision: ParameterPrecision, name: String): MaterialBuilder
+
+    /** Names a custom interpolant ([Variable] slot) passed from the vertex to the fragment stage. */
     fun variable(variable: Variable, name: String): MaterialBuilder
+
+    /** Requires the given vertex [attribute] to be present in rendered geometry (e.g. UV1, COLOR). */
     fun require(attribute: VertexAttribute): MaterialBuilder
+
+    /** Sets the fragment-stage material code: a GLSL `void material(inout MaterialInputs)` body. */
     fun material(code: String): MaterialBuilder
+
+    /** Sets the vertex-stage material code: a GLSL `void materialVertex(inout MaterialVertexInputs)` body. */
     fun materialVertex(code: String): MaterialBuilder
+
+    /** Sets how the material blends with the render target ([BlendingMode.OPAQUE] by default). */
     fun blending(mode: BlendingMode): MaterialBuilder
+
+    /** Sets how the post-lighting color blends with the lit result. */
     fun postLightingBlending(mode: BlendingMode): MaterialBuilder
+
+    /** Sets the coordinate space of the vertex output ([VertexDomain.OBJECT] by default). */
     fun vertexDomain(vertexDomain: VertexDomain): MaterialBuilder
+
+    /** Sets face culling ([CullingMode.BACK] by default). */
     fun culling(mode: CullingMode): MaterialBuilder
+
+    /** Enables/disables writes to the color buffer (default: true). */
     fun colorWrite(enable: Boolean): MaterialBuilder
+
+    /** Enables/disables writes to the depth buffer (default: true, except for blended modes). */
     fun depthWrite(enable: Boolean): MaterialBuilder
+
+    /** Enables/disables depth testing (default: true). */
     fun depthCulling(enable: Boolean): MaterialBuilder
+
+    /** Renders both faces and flips the normal on back faces; implies [CullingMode.NONE]. */
     fun doubleSided(doubleSided: Boolean): MaterialBuilder
+
+    /** Sets the alpha cutoff for [BlendingMode.MASKED] (default: 0.4). */
     fun maskThreshold(threshold: Float): MaterialBuilder
+
+    /** Converts fragment alpha to MSAA coverage; smoother [BlendingMode.MASKED] edges under MSAA. */
     fun alphaToCoverage(enable: Boolean): MaterialBuilder
+
+    /** UNLIT only: multiplies the final color by the shadowing factor, for shadow-receiver planes. */
     fun shadowMultiplier(shadowMultiplier: Boolean): MaterialBuilder
+
+    /** Makes this transparent material cast (dithered) transparent shadows. */
     fun transparentShadow(transparentShadow: Boolean): MaterialBuilder
+
+    /** Enables colored shadow penumbras for this material's transparent shadows. */
     fun coloredPenumbra(coloredPenumbra: Boolean): MaterialBuilder
+
+    /** Reduces specular shimmering/aliasing on curved geometry (LIT models only). */
     fun specularAntiAliasing(specularAntiAliasing: Boolean): MaterialBuilder
+
+    /** Screen-space variance of the specular AA filter kernel, in `[0, 1]` (default: 0.15). */
     fun specularAntiAliasingVariance(variance: Float): MaterialBuilder
+
+    /** Clamping threshold of the specular AA roughness increase, in `[0, 1]` (default: 0.2). */
     fun specularAntiAliasingThreshold(threshold: Float): MaterialBuilder
+
+    /** Sets where refracted light is sampled from ([RefractionMode.NONE] by default). */
     fun refractionMode(mode: RefractionMode): MaterialBuilder
+
+    /** Sets where reflections are sampled from ([ReflectionMode.DEFAULT] by default). */
     fun reflectionMode(mode: ReflectionMode): MaterialBuilder
+
+    /** Sets the refraction geometry model ([RefractionType.SOLID] by default). */
     fun refractionType(type: RefractionType): MaterialBuilder
+
+    /** Makes the clear coat layer's IOR affect the base layer (physically correct; default: true). */
     fun clearCoatIorChange(clearCoatIorChange: Boolean): MaterialBuilder
+
+    /** Flips the V texture coordinate at compile time (default: true, matching Filament's convention). */
     fun flipUV(flipUV: Boolean): MaterialBuilder
+
+    /** Enables custom surface shading: the material provides its own `surfaceShading()` function. */
     fun customSurfaceShading(customSurfaceShading: Boolean): MaterialBuilder
+
+    /** Simulates extra light bounces in occluded areas to reduce over-darkening from AO. */
     fun multiBounceAmbientOcclusion(multiBounceAO: Boolean): MaterialBuilder
+
+    /** Sets how AO is applied to specular lighting ([SpecularAmbientOcclusion.NONE] by default). */
     fun specularAmbientOcclusion(specularAO: SpecularAmbientOcclusion): MaterialBuilder
+
+    /** Sets the transparency rendering strategy ([TransparencyMode.DEFAULT] by default). */
     fun transparencyMode(mode: TransparencyMode): MaterialBuilder
+
+    /** Selects the platform class to generate shaders for ([Platform.ALL] to cover everything). */
     fun platform(platform: Platform): MaterialBuilder
+
+    /** Selects the graphics API(s) to generate shaders for; fewer APIs → smaller package. */
     fun targetApi(api: TargetApi): MaterialBuilder
+
+    /** Sets the shader optimization level ([Optimization.PERFORMANCE] by default). */
     fun optimization(optimization: Optimization): MaterialBuilder
+
+    /** Bitmask of shader variants to exclude from compilation, shrinking the package. */
     fun variantFilter(variantFilter: Int): MaterialBuilder
+
+    /** Uses the legacy (non-CPU-skinning-aware) morph target implementation. */
     fun useLegacyMorphing(): MaterialBuilder
 }

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/View.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/View.kt
@@ -837,6 +837,7 @@ expect class View {
         var customResolve: Boolean
     }
 
+    /** Debug name of this View, shown in diagnostic tools. */
     var name: String?
 
     /**
@@ -848,52 +849,149 @@ expect class View {
      * is automatically dissociated (the View's scene becomes `null`).
      */
     var scene: Scene?
+
+    /**
+     * The [Camera] this View is rendered from. A Camera can be associated to several Views.
+     *
+     * Set to `null` to dissociate the current Camera; the View does not take ownership.
+     */
     var camera: Camera?
+
+    /** Whether a [Camera] is currently associated with this View. */
     val hasCamera: Boolean
+
+    /** The rectangular region of the render target this View renders into. */
     var viewport: Viewport
+
+    /** How this View's result blends over the render target's existing content. */
     var blendMode: BlendMode
+
+    /**
+     * Sets which layers are visible: for each bit set in [select], visibility is taken from the
+     * corresponding bit in [values]. Renderables are assigned layers via
+     * `RenderableManager.setLayerMask`. By default all layers are visible.
+     */
     fun setVisibleLayers(select: Int, values: Int)
+
+    /** Convenience over [setVisibleLayers] toggling a single layer (0–7). */
     fun setLayerEnabled(layer: Int, enabled: Boolean)
+
+    /** Returns the current visible-layer bitmask. */
     fun getVisibleLayers(): Int
+
+    /**
+     * Enables or disables the post-processing stage (tone mapping, bloom, color grading, FXAA,
+     * dynamic scaling, …). Disabling it also disables features that depend on it. Default: enabled.
+     */
     var isPostProcessingEnabled: Boolean
+
+    /** Dithering applied to the final render to hide banding. Default: [Dithering.TEMPORAL]. */
     var dithering: Dithering
+
+    /** Dynamic-resolution (render scaling) configuration for this View. */
     var dynamicResolutionOptions: DynamicResolutionOptions
+
+    /** Returns the `[x, y]` scale factors dynamic resolution used on the last frame. */
     fun getLastDynamicResolutionScale(): FloatArray
+
+    /** Global quality/performance trade-offs (e.g. color-buffer precision) for this View. */
     var renderQuality: RenderQuality
+
+    /** Bloom post-processing configuration (requires post-processing enabled). */
     var bloomOptions: BloomOptions
+
+    /** Large-scale atmospheric fog configuration. */
     var fogOptions: FogOptions
+
+    /** Depth-of-field post-processing configuration (needs a focused [camera]). */
     var depthOfFieldOptions: DepthOfFieldOptions
+
+    /** Vignette post-processing configuration. */
     var vignetteOptions: VignetteOptions
+
+    /** Screen-space ambient occlusion (SSAO) configuration. */
     var ambientOcclusionOptions: AmbientOcclusionOptions
+
+    /** Temporal anti-aliasing (TAA) configuration; effective when [antiAliasing] permits it. */
     var temporalAntiAliasingOptions: TemporalAntiAliasingOptions
+
+    /** Screen-space reflections configuration. */
     var screenSpaceReflectionsOptions: ScreenSpaceReflectionsOptions
 
+    /**
+     * Off-screen [RenderTarget] to render into, or `null` to render into the SwapChain.
+     * The render target is not owned by the View.
+     */
     var renderTarget: RenderTarget?
 
+    /** Shadow mapping technique for the whole View ([ShadowType.PCF], VSM, DPCF, PCSS). */
     var shadowType: ShadowType
+
+    /** Variance shadow mapping options; only applies when [shadowType] is [ShadowType.VSM]. */
     var vsmShadowOptions: VsmShadowOptions
+
+    /** Soft shadow options; only applies when [shadowType] is DPCF or PCSS. */
     var softShadowOptions: SoftShadowOptions
+
+    /** Guard-band configuration, letting some effects sample outside the viewport. */
     var guardBandOptions: GuardBandOptions
+
+    /** Stereoscopic (VR) rendering configuration; must be set before the first frame. */
     var stereoscopicOptions: StereoscopicOptions
+
+    /** Hardware MSAA configuration (independent of [antiAliasing]/TAA). */
     var multiSampleAntiAliasingOptions: MultiSampleAntiAliasingOptions
 
+    /** Culls renderables outside the camera frustum. Default: true (disable only for debugging). */
     var isFrustumCullingEnabled: Boolean
+
+    /** Master switch for shadow mapping in this View. Default: true. */
     var isShadowingEnabled: Boolean
+
+    /** Enables screen-space refraction for refractive materials. Default: true. */
     var isScreenSpaceRefractionEnabled: Boolean
+
+    /** Allocates a stencil buffer for this View (required for stencil-based effects). Default: false. */
     var isStencilBufferEnabled: Boolean
+
+    /**
+     * Inverts the winding order considered front-facing (counter-clockwise by default).
+     * Useful for mirror-like reflections rendered with a flipped camera.
+     */
     var isFrontFaceWindingInverted: Boolean
+
+    /** Includes transparent renderables in [pick] results. Default: true. */
     var isTransparentPickingEnabled: Boolean
 
+    /** Sets the float4 material-global value at [index] (0–3), readable from all materials. */
     fun setMaterialGlobal(index: Int, value: FloatArray)
+
+    /** Returns the float4 material-global value at [index] (0–3). */
     fun getMaterialGlobal(index: Int): FloatArray
+
+    /** Discards accumulated frame history (TAA, SSR). Call after a camera cut to avoid ghosting. */
     fun clearFrameHistory(engine: Engine)
-    
+
+    /**
+     * Sets the near/far planes (in world units, > 0) used to compute the froxel grid for dynamic
+     * lighting. Only lights within this range are lit. Defaults: 5 / 100.
+     */
     fun setDynamicLightingOptions(zNear: Float, zFar: Float)
 
+    /** Entity representing the large-scale fog object; can be transformed via TransformManager. */
     val fogEntity: Int
+
+    /** Post-process anti-aliasing operator ([AntiAliasing.FXAA] by default). */
     var antiAliasing: AntiAliasing
+
+    /** Color grading to apply, or `null` for the default. The View does not own it. */
     var colorGrading: ColorGrading?
 
+    /**
+     * Asynchronously picks the renderable at viewport coordinates ([x], [y]) — origin bottom-left —
+     * and invokes [callback] with the result a few frames later. Requires the picking feature
+     * (enabled by default) and a rendered frame.
+     */
     fun pick(x: Int, y: Int, callback: (PickingQueryResult) -> Unit)
 }
 

--- a/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/FilamentAsset.kt
+++ b/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/FilamentAsset.kt
@@ -21,32 +21,104 @@ import io.github.erkko68.filament.Entity
  * @see ResourceLoader
  */
 expect class FilamentAsset {
+    /**
+     * Gets the transform root of the asset, an extra entity with no matching glTF node.
+     *
+     * It exists so the entire asset can be transformed as one. For instanced assets this is a
+     * "super root" whose children are the per-instance roots, allowing all instances to be
+     * moved en masse.
+     */
     fun getRoot(): Entity
+
+    /**
+     * Pops a ready renderable off the async-load queue, or returns 0 if none is ready.
+     *
+     * Allows progressive reveal: add renderables to the scene as their textures become ready
+     * during [ResourceLoader.asyncBeginLoad], e.g. `while ((e = popRenderable()) != 0) scene.addEntity(e)`.
+     * Use [ResourceLoader.asyncGetLoadProgress] for the overall progress. Progressive reveal is
+     * not supported for dynamically added instances.
+     */
     fun popRenderable(): Entity
+
+    /**
+     * Pops up to `entities.size` ready renderables off the async-load queue into [entities].
+     *
+     * @return the number of entities written.
+     * @see popRenderable
+     */
     fun popRenderables(entities: IntArray): Int
-    
+
+    /**
+     * Gets the list of entities, one per glTF node. All have a Transform component; some also
+     * have a Renderable and/or Light component.
+     */
     fun getEntities(): IntArray
+
+    /** Gets the entities representing lights. All of these have a Light component. */
     fun getLightEntities(): IntArray
+
+    /** Gets the entities that have Renderable components. */
     fun getRenderableEntities(): IntArray
+
+    /**
+     * Gets the entities representing cameras. All of these have a Camera component.
+     *
+     * gltfio always sets a perspective projection with aspect ratio 1.0 and then applies the
+     * glTF file's aspect ratio through the camera's *scaling* matrix, so clients can adjust
+     * the aspect ratio independently of the projection:
+     * `camera.setScaling(1.0 / newAspectRatio, 1.0)`.
+     */
     fun getCameraEntities(): IntArray
-    
+
+    /** Gets all entities whose name label matches [name] exactly. */
     fun getEntitiesByName(name: String): IntArray
+
+    /** Gets all entities whose name label starts with [prefix]. */
     fun getEntitiesByPrefix(prefix: String): IntArray
+
+    /** Returns the first entity with the given name, or 0 if none exists. */
     fun getFirstEntityByName(name: String): Entity
-    
+
+    /** Gets the number of entities returned by [getEntities]. */
     fun getEntityCount(): Int
+
+    /** Returns the number of instances created from this asset (>= 1 unless detached). */
     fun getAssetInstanceCount(): Int
+
+    /** Returns every [FilamentInstance] created from this asset. */
     fun getAssetInstances(): Array<FilamentInstance>
-    
+
+    /**
+     * Gets the bounding box computed from the min/max values in the glTF accessors.
+     *
+     * This is a straightforward load-time AABB over the asset data — it does not account for
+     * per-instance transforms (see [FilamentInstance.getBoundingBox] for that).
+     */
     fun getBoundingBox(): Box
+
+    /** Gets the name label for the given entity, or null if it has none. */
     fun getName(entity: Entity): String?
+
+    /** Gets the glTF `extras` string for the given node entity (or for the asset itself), if any. */
     fun getExtras(entity: Entity): String?
+
+    /** Gets the morph target names declared on the given entity, in target order. */
     fun getMorphTargetNames(entity: Entity): Array<String>
-    
+
+    /** Gets the URIs of all externally-referenced buffers/textures (to feed [ResourceLoader]). */
     fun getResourceUris(): Array<String>
-    
+
+    /**
+     * Reclaims CPU-side memory for URI strings, binding lists, and raw animation data.
+     *
+     * Call only after [ResourceLoader.loadResources]. On an instanced asset this prevents the
+     * creation of new instances.
+     */
     fun releaseSourceData()
 
+    /** Returns the [Engine] associated with the [AssetLoader] that created this asset. */
     fun getEngine(): Engine
+
+    /** Convenience accessor for the first instance ([getAssetInstances]`[0]`). */
     fun getInstance(): FilamentInstance
 }

--- a/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/FilamentInstance.kt
+++ b/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/FilamentInstance.kt
@@ -34,23 +34,68 @@ expect class FilamentInstance {
      */
     constructor()
 
+    /** Gets the transform root entity of this instance, which has no matching glTF node. */
     fun getRoot(): Int
+
+    /**
+     * Gets the entities of this instance, one per glTF node. All have a Transform component;
+     * some also have a Renderable or Name component.
+     */
     fun getEntities(): IntArray
+
+    /** Gets the number of entities returned by [getEntities]. */
     fun getEntityCount(): Int
-    
+
+    /**
+     * Returns the animation engine for this instance.
+     *
+     * An animator can be obtained either from an individual instance (independent per-instance
+     * playback) or from the originating [FilamentAsset] (frame shared amongst all instances).
+     * The animator is owned by the asset — do not destroy it manually.
+     */
     fun getAnimator(): Animator
+
+    /**
+     * Gets the axis-aligned bounding box from the min/max values in the glTF accessors,
+     * transformed for this instance.
+     */
     fun getBoundingBox(): Box
-    
+
+    /** Gets the [FilamentAsset] that owns this instance. */
     fun getAsset(): FilamentAsset
-    
+
+    /** Gets the number of skins declared in the asset. */
     fun getSkinCount(): Int
+
+    /** Gets the names of all skins, in skin-index order. */
     fun getSkinNames(): Array<String>
+
+    /**
+     * Attaches the given skin to the given node entity, which must have an associated mesh with
+     * BONE_INDICES and BONE_WEIGHTS attributes. No-op if the skin index or target is invalid.
+     */
     fun attachSkin(skinIndex: Int, target: Int)
+
+    /** Detaches the given skin from the given node entity. No-op if skin index or target is invalid. */
     fun detachSkin(skinIndex: Int, target: Int)
+
+    /** Gets the number of joints in the skin at [skinIndex]. */
     fun getJointCountAt(skinIndex: Int): Int
+
+    /** Gets the joint entities of the skin at [skinIndex]. */
     fun getJointsAt(skinIndex: Int): IntArray
-    
+
+    /**
+     * Applies the material variant at [variantIndex] to all primitives in this instance.
+     * Ignored if the index is out of bounds.
+     *
+     * @see getMaterialVariantNames
+     */
     fun applyMaterialVariant(variantIndex: Int)
+
+    /** Gets all material instances of this instance. These are already bound to renderables. */
     fun getMaterialInstances(): Array<io.github.erkko68.filament.MaterialInstance>
+
+    /** Gets the names of all material variants declared in the asset, in variant-index order. */
     fun getMaterialVariantNames(): Array<String>
 }

--- a/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/MaterialKey.kt
+++ b/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/MaterialKey.kt
@@ -16,41 +16,81 @@ expect class MaterialKey {
      */
     constructor()
 
+    /** Renders both faces of each triangle (glTF `doubleSided`). */
     var doubleSided: Boolean
+    /** Uses the unlit shading model (`KHR_materials_unlit`). */
     var unlit: Boolean
+    /** The mesh provides per-vertex COLOR_0 data to be multiplied into base color. */
     var hasVertexColors: Boolean
+    /** A base color texture is bound. */
     var hasBaseColorTexture: Boolean
+    /** A tangent-space normal map is bound. */
     var hasNormalTexture: Boolean
+    /** An ambient-occlusion texture is bound. */
     var hasOcclusionTexture: Boolean
+    /** An emissive texture is bound. */
     var hasEmissiveTexture: Boolean
+    /** Uses the legacy specular-glossiness workflow (`KHR_materials_pbrSpecularGlossiness`). */
     var useSpecularGlossiness: Boolean
+    /** Alpha mode: 0 = OPAQUE, 1 = MASK (alpha cutoff), 2 = BLEND. */
     var alphaMode: Int
+    /** Enables shader diagnostics (visualizes the material as a debug aid). */
     var enableDiagnostics: Boolean
+    /** A metallic-roughness texture is bound (specular-glossiness texture when [useSpecularGlossiness]). */
     var hasMetallicRoughnessTexture: Boolean
+    /** glTF texcoord set index for the metallic-roughness texture. */
     var metallicRoughnessUV: Int
+    /** glTF texcoord set index for the base color texture. */
     var baseColorUV: Int
+    /** A clearcoat intensity texture is bound. */
     var hasClearCoatTexture: Boolean
+    /** glTF texcoord set index for the clearcoat texture. */
     var clearCoatUV: Int
+    /** A clearcoat roughness texture is bound. */
     var hasClearCoatRoughnessTexture: Boolean
+    /** glTF texcoord set index for the clearcoat roughness texture. */
     var clearCoatRoughnessUV: Int
+    /** A clearcoat normal map is bound. */
     var hasClearCoatNormalTexture: Boolean
+    /** glTF texcoord set index for the clearcoat normal map. */
     var clearCoatNormalUV: Int
+    /** The clearcoat layer is enabled (`KHR_materials_clearcoat`). */
     var hasClearCoat: Boolean
+    /** Transmission is enabled (`KHR_materials_transmission`). */
     var hasTransmission: Boolean
+    /** One or more textures use `KHR_texture_transform`. */
     var hasTextureTransforms: Boolean
+    /** glTF texcoord set index for the emissive texture. */
     var emissiveUV: Int
+    /** glTF texcoord set index for the ambient-occlusion texture. */
     var aoUV: Int
+    /** glTF texcoord set index for the normal map. */
     var normalUV: Int
+    /** A transmission texture is bound. */
     var hasTransmissionTexture: Boolean
+    /** glTF texcoord set index for the transmission texture. */
     var transmissionUV: Int
+    /** A sheen color texture is bound. */
     var hasSheenColorTexture: Boolean
+    /** glTF texcoord set index for the sheen color texture. */
     var sheenColorUV: Int
+    /** A sheen roughness texture is bound. */
     var hasSheenRoughnessTexture: Boolean
+    /** glTF texcoord set index for the sheen roughness texture. */
     var sheenRoughnessUV: Int
+    /** A volume thickness texture is bound (`KHR_materials_volume`). */
     var hasVolumeThicknessTexture: Boolean
+    /** glTF texcoord set index for the volume thickness texture. */
     var volumeThicknessUV: Int
+    /** The sheen layer is enabled (`KHR_materials_sheen`). */
     var hasSheen: Boolean
+    /** A custom index of refraction is set (`KHR_materials_ior`). */
     var hasIOR: Boolean
 
+    /**
+     * Mutates this key to trim requested features down to what the provider supports, and fills
+     * [uvmap] with the resulting glTF-texcoord → Filament-UV-set mapping. Called by providers
+     * before material creation.
+     */
     fun constrainMaterial(uvmap: IntArray)
 }

--- a/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/MaterialProvider.kt
+++ b/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/MaterialProvider.kt
@@ -13,11 +13,35 @@ import io.github.erkko68.filament.Engine
  * @see AssetLoader
  */
 expect interface MaterialProvider {
+    /**
+     * Creates or fetches a compiled Filament material, then creates an instance from it.
+     *
+     * @param config Properties of the glTF material; may be mutated to trim unsupported features.
+     * @param uvmap Output: mapping from glTF texcoord sets to Filament UV sets, written by the provider.
+     * @param label Optional debug name for the material instance.
+     * @param extras Optional glTF extras as stringified JSON (not part of the cache key).
+     */
     fun createMaterialInstance(config: MaterialKey, uvmap: IntArray, label: String? = null, extras: String? = null): io.github.erkko68.filament.MaterialInstance?
+
+    /** Creates or fetches the compiled Filament material corresponding to [config], without instancing it. */
     fun getMaterial(config: MaterialKey, uvmap: IntArray, label: String? = null): io.github.erkko68.filament.Material?
+
+    /** Gets the provider's cache of compiled materials (weak references). */
     fun getMaterials(): Array<io.github.erkko68.filament.Material>
+
+    /**
+     * Returns true if the given vertex attribute must be present. Some providers (e.g.
+     * ubershader) require dummy attribute values when the glTF model does not provide them.
+     */
     fun needsDummyData(attrib: Int): Boolean
+
+    /**
+     * Destroys all cached materials. NOT called automatically on [destroy], which lets clients
+     * take ownership of the cache if desired.
+     */
     fun destroyMaterials()
+
+    /** Frees the provider itself (cached materials survive unless [destroyMaterials] was called). */
     fun destroy()
 }
 

--- a/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/ResourceLoader.kt
+++ b/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/ResourceLoader.kt
@@ -37,17 +37,60 @@ expect class ResourceLoader {
      * @param normalizeSkinningWeights Whether to normalize skinning weights to [0, 1] range.
      */
     constructor(engine: Engine, normalizeSkinningWeights: Boolean = false)
-    
+
+    /**
+     * Destroys this loader and frees its internal caches. Must happen on the same thread that
+     * calls `Renderer.render()`, because the loader listens to buffer callbacks to know when
+     * CPU-side data blobs can be freed.
+     */
     fun destroy()
-    
+
+    /**
+     * Feeds the binary content of an external resource into the loader's URI cache.
+     *
+     * Every resource returned by [FilamentAsset.getResourceUris] should be added before calling
+     * [loadResources] or [asyncBeginLoad]. Self-contained GLB files typically need no calls.
+     */
     fun addResourceData(url: String, data: ByteArray)
+
+    /** Checks whether the given resource URI has already been added via [addResourceData]. */
     fun hasResourceData(url: String): Boolean
+
+    /**
+     * Synchronously loads resources for [asset] from the URI cache and finalizes the asset:
+     * transforms vertex data if necessary, decodes images, and supplies tangent data.
+     *
+     * @return false if resources were already loaded, or if one or more could not be loaded.
+     * @see asyncBeginLoad
+     */
     fun loadResources(asset: FilamentAsset): Boolean
-    
+
+    /**
+     * Starts an asynchronous resource load (texture decoding may use worker threads).
+     * Requires periodic calls to [asyncUpdateLoad] until [asyncGetLoadProgress] reaches 1.0.
+     *
+     * @return false if the loading process could not start.
+     */
     fun asyncBeginLoad(asset: FilamentAsset): Boolean
+
+    /** Gets the status of an asynchronous load as a percentage in `[0, 1]`. */
     fun asyncGetLoadProgress(): Float
+
+    /**
+     * Performs any pending main-thread work of an asynchronous load. Call periodically until
+     * [asyncGetLoadProgress] returns 1.0; harmless after that.
+     */
     fun asyncUpdateLoad()
+
+    /**
+     * Cancels pending decoder jobs, frees all CPU-side texel data, and flushes the Engine.
+     * Only needed if [asyncBeginLoad] was used and cancellation is required before completion.
+     */
     fun asyncCancelLoad()
-    
+
+    /**
+     * Frees memory by evicting the URI cache populated via [addResourceData]. Call only after a
+     * model is fully loaded or loading has been cancelled.
+     */
     fun evictResourceData()
 }


### PR DESCRIPTION
Completes the Doxygen→KDoc migration from the C++ headers to the Kotlin expect surface. The remaining gaps were narrower than estimated — most of the core module was already documented:

- **gltfio** (the biggest hole): `FilamentAsset`, `FilamentInstance`, `ResourceLoader`, `MaterialProvider`/`UbershaderProvider`, and `MaterialKey` (every flag and UV field), migrated from `include/gltfio/*.h`.
- **filamat `MaterialBuilder`**: the 11 undocumented enums (with per-entry docs) and all 46 builder methods.
- **Core `View`**: the ~45 undocumented members of the main class body (option properties, layers, picking, material globals, `pick`).

Deliberately out of scope: the vendored kotlin-math files (`Vector`/`Matrix`/`Quaternion`/`Half` stay aligned with Romain Guy's upstream) and `filament-compose`, whose public surface already carries class-level `@param`/`@property` docs.

Verified: all modules compile; `:kotlin:gltfio:dokkaGenerate` renders with zero unresolved links; `apiCheck` unaffected (docs only).

**Stacked on #65** — merges after it (GitHub retargets automatically).