### PR TITLE
docs(api): @PlatformGap annotation + per-platform binding coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Each entry is one line; click the version link at the bottom for the full diff.
 
 ## [Unreleased]
 
+### Added
+- **`@PlatformGap` annotation + binding-coverage table** (`filament`, all modules): every common API whose platform binding is missing or degraded (all current gaps are on web, where `filament.js` doesn't bind the function) is now annotated with `@PlatformGap(platforms, behavior)` — visible in the IDE and the generated API reference — and listed in a per-API coverage table in [Platform Notes](docs/platform-notes.md#binding-coverage). Android/iOS/JVM expose the full common API.
+
 ### Changed
 - **Python is no longer a build dependency** (build): the prebuilt/header/jextract download scripts were ported to pure-JVM Gradle tasks in `build-logic` (commons-compress for tar.gz), keeping the same task names, cache dirs, and version stamping — and making the prebuilt downloads fully version-aware, so bumping `filaVersion` re-extracts automatically. `setup-python` dropped from all CI workflows.
 - **`buildSrc` became the `build-logic` included build** (build): convention-plugin edits no longer invalidate the whole main build's task graph.

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -87,17 +87,40 @@ Then copy `filament.js` and `filament.wasm` into your `src/jsMain/resources/`. (
 `filament.d.ts` is build-time only — the `:js` module's Kotlin externals are generated
 against it by hand; see [`web/README.md`](../web/README.md).)
 
-### Current limitations
+### Binding coverage
 
-APIs without a Filament.js equivalent throw `UnsupportedOperationException` with a workaround pointer:
+**Android, iOS, and Desktop/JVM expose the full common API.** Web is the only platform with
+gaps — almost all because upstream `filament.js` (embind, `jsbindings.cpp`) does not register
+the corresponding function. Every gap below is also marked in source with **`@PlatformGap`**
+(from the core `filament` module), so it shows up in the IDE and in the generated
+[API reference](https://erkko68.github.io/filament-kmp/api/) on the affected declaration itself.
 
-- **`filamat.MaterialBuilder`** — runtime material compilation is unavailable. Compile materials offline with `matc` and load the resulting `.filamat` via `Material.Builder().payload(...)`.
-- **`gltfio.MaterialProvider.createMaterialInstance()` / `getMaterial()`** — the default ubershader path is not exposed. Supply your own precompiled materials.
-- **`filament-utils.HDRLoader.createTexture`** — Radiance/RGBE decoding is unavailable. Convert HDRs to KTX1 offline with `cmgen`.
-- **`filament-utils.KTX1Loader.getSphericalHarmonics`** — SH extraction is unavailable. Precompute SH offline and bake the coefficients into your app data.
-- **`View.shadowType` (shadow technique selection)** — Filament's web build does not bind `View::setShadowType` (absent from both `filament.js` and `filament.wasm`), so the technique is locked to the default **PCF**. In `filament-compose` this means `Shadows.Vsm`, `Shadows.Dpcf`, and `Shadows.Pcss` are silently ignored on web — only `Shadows.Pcf` and `null` (disabled, via the bound `setShadowingEnabled`) take effect. Hard PCF shadows render correctly; soft/VSM shadows are unavailable until upstream binds the setter. (Other platforms support all techniques.)
+| API | Behavior on web | Workaround |
+| :--- | :--- | :--- |
+| `filamat.MaterialBuilder` | Throws on construction | Compile materials offline with `matc`, load the `.filamat` via `Material.Builder().payload(...)` |
+| `gltfio.UbershaderProvider` (`createMaterialInstance`/`getMaterial`) | Throws | Supply precompiled materials (e.g. the `filament-compose` standard materials) |
+| `gltfio.FilamentAsset.getAssetInstances` / `getAssetInstanceCount` | Throws (embind "unbound types") | Track instances returned by `AssetLoader.createInstance` yourself |
+| `gltfio.FilamentAsset.getMorphTargetNames` | Returns an empty array | Read target names from the glTF JSON directly |
+| `gltfio.FilamentInstance.getMaterialInstances` | Throws (embind "unbound types") | — |
+| `gltfio.FilamentInstance.getJointCountAt` / `getJointsAt` | Returns 0 / empty array | — (skinned *playback* via `Animator` works) |
+| `filament-utils.HDRLoader.createTexture` | Throws | Convert HDRs to KTX1 offline with `cmgen` |
+| `View.shadowType` | Silent no-op — technique locked to **PCF** (stock prebuilts don't bind `setShadowType`) | In `filament-compose`, `Shadows.Vsm`/`Dpcf`/`Pcss` are ignored on web; `Shadows.Pcf` and `null` work |
+| `View.isFrustumCullingEnabled` | Setter is a silent no-op (getter tracked locally) | — |
+| `LightManager.Builder.shadowOptions` | Silent no-op (embind can't marshal the `mat4f` field) | Per-light shadow options stay at Filament defaults |
+| `LightManager.getComponentCount` | Throws | — |
+| `Renderer.copyFrame` / `readPixels` (both overloads) | Silent no-op | — |
+| `RenderableManager` non-indexed `geometry`/`setGeometryAt` overloads | Throws | Use the indexed overloads (with an `IndexBuffer`) |
+| `Stream` | Throws on construction | External/native video streams have no web equivalent |
+| `SkinningBuffer` | `Builder.build` throws; `setBonesAt` is a no-op | glTF skinning works through `gltfio` |
+| `MorphTargetBuffer` | `Builder.build` throws | glTF morph targets work through `gltfio` (`GltfInstance.morphWeights`) |
+| `Fence` / `Engine.createFence` | Throws | — |
+| `Engine.isValid{Fence,SkinningBuffer,MorphTargetBuffer,Stream}` | Throws | — |
+| `Engine.paused` | Tracked locally only; does not pause rendering | Stop your own frame loop instead |
+| `Texture.Companion.isTextureSwizzleSupported` | Always `false` | — |
+| `Camera.getFieldOfViewInDegrees` | Always `0.0` | Track the FOV you set yourself |
+| `SurfaceOrientation.Builder.tangents` | Silent no-op | Provide normals/uvs and let the builder derive the orientation |
 
-`TextureLoader` works for PNG, JPEG, and KTX1; it returns `null` only on decode failure or empty input. `Manipulator` works fully — `filament-utils` ships a pure-Kotlin implementation on JS; `rememberOrbitCameraState` from `filament-compose` is the recommended ergonomic wrapper.
+`TextureLoader` works for PNG, JPEG, and KTX1; it returns `null` only on decode failure or empty input. `KTX1Loader` works fully, including `getSphericalHarmonics`. `Manipulator` works fully — `filament-utils` ships a pure-Kotlin implementation on JS; `rememberOrbitCameraState` from `filament-compose` is the recommended ergonomic wrapper.
 
 Suitable for simple scenes with custom materials. Not yet suitable for full glTF pipelines using the default ubershader, or image-based lighting via raw HDR files.
 

--- a/kotlin/filamat/src/commonMain/kotlin/io/github/erkko68/filament/filamat/MaterialBuilder.kt
+++ b/kotlin/filamat/src/commonMain/kotlin/io/github/erkko68/filament/filamat/MaterialBuilder.kt
@@ -1,6 +1,8 @@
 package io.github.erkko68.filament.filamat
 
 import io.github.erkko68.filament.VertexBuffer.VertexAttribute
+import io.github.erkko68.filament.FilamentPlatform
+import io.github.erkko68.filament.PlatformGap
 
 /**
  * MaterialBuilder compiles Filament material source code into binary packages.
@@ -19,6 +21,7 @@ import io.github.erkko68.filament.VertexBuffer.VertexAttribute
  * @see Filamat
  * @see MaterialPackage
  */
+@PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException on construction — runtime material compilation is not available on web; precompile .filamat assets instead.")
 expect class MaterialBuilder() {
     /**
      * Shading model determines how light interacts with the material surface.

--- a/kotlin/filament-utils/src/commonMain/kotlin/io/github/erkko68/filament/utils/HDRLoader.kt
+++ b/kotlin/filament-utils/src/commonMain/kotlin/io/github/erkko68/filament/utils/HDRLoader.kt
@@ -2,6 +2,8 @@ package io.github.erkko68.filament.utils
 
 import io.github.erkko68.filament.Engine
 import io.github.erkko68.filament.Texture
+import io.github.erkko68.filament.FilamentPlatform
+import io.github.erkko68.filament.PlatformGap
 
 /**
  * Decodes an HDR image from raw bytes into a Filament [Texture].
@@ -16,5 +18,6 @@ expect object HDRLoader {
      * @return the created [Texture], or null on failure
      * @throws UnsupportedOperationException on Web — `filament.js` exposes no Radiance/RGBE decoder.
      */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — filament.js exposes no Radiance/RGBE decoder.")
     fun createTexture(engine: Engine, buffer: ByteArray, internalFormat: Texture.InternalFormat): Texture?
 }

--- a/kotlin/filament/api/jvm/filament.api
+++ b/kotlin/filament/api/jvm/filament.api
@@ -458,6 +458,16 @@ public final class io/github/erkko68/filament/Filament {
 	public final fun init ()V
 }
 
+public final class io/github/erkko68/filament/FilamentPlatform : java/lang/Enum {
+	public static final field ANDROID Lio/github/erkko68/filament/FilamentPlatform;
+	public static final field IOS Lio/github/erkko68/filament/FilamentPlatform;
+	public static final field JVM Lio/github/erkko68/filament/FilamentPlatform;
+	public static final field WEB Lio/github/erkko68/filament/FilamentPlatform;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/erkko68/filament/FilamentPlatform;
+	public static fun values ()[Lio/github/erkko68/filament/FilamentPlatform;
+}
+
 public final class io/github/erkko68/filament/IndexBuffer {
 	public final fun getIndexCount ()I
 	public final fun setBuffer (Lio/github/erkko68/filament/Engine;[B)V
@@ -995,6 +1005,11 @@ public final class io/github/erkko68/filament/MorphTargetBuffer$Builder {
 public final class io/github/erkko68/filament/NativeSurface {
 	public fun <init> (Ljava/lang/Object;)V
 	public final fun getNativeWindow ()Ljava/lang/Object;
+}
+
+public abstract interface annotation class io/github/erkko68/filament/PlatformGap : java/lang/annotation/Annotation {
+	public abstract fun behavior ()Ljava/lang/String;
+	public abstract fun platforms ()[Lio/github/erkko68/filament/FilamentPlatform;
 }
 
 public final class io/github/erkko68/filament/RenderTarget {

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Camera.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Camera.kt
@@ -364,6 +364,7 @@ expect class Camera {
      * @param direction Axis (VERTICAL or HORIZONTAL) for which to return FOV
      * @return Full field-of-view in degrees
      */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "always returns 0.0 — Camera::getFieldOfViewInDegrees is not bound in filament.js.")
     fun getFieldOfViewInDegrees(direction: Fov): Double
 
     /**

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Engine.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Engine.kt
@@ -350,6 +350,7 @@ expect class Engine {
     /** Validate a Scene. @return true if valid. */
     fun isValidScene(scene: Scene): Boolean
     /** Validate a Fence. @return true if valid. @throws UnsupportedOperationException on JS — Fence is unbound on web. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — not bound in filament.js.")
     fun isValidFence(fence: Fence): Boolean
     /** Validate a RenderTarget. @return true if valid. */
     fun isValidRenderTarget(renderTarget: RenderTarget): Boolean
@@ -358,8 +359,10 @@ expect class Engine {
     /** Validate a VertexBuffer. @return true if valid. */
     fun isValidVertexBuffer(vertexBuffer: VertexBuffer): Boolean
     /** Validate a SkinningBuffer. @return true if valid. @throws UnsupportedOperationException on JS — SkinningBuffer is unbound on web. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — not bound in filament.js.")
     fun isValidSkinningBuffer(skinningBuffer: SkinningBuffer): Boolean
     /** Validate a MorphTargetBuffer. @return true if valid. @throws UnsupportedOperationException on JS — MorphTargetBuffer is unbound on web. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — not bound in filament.js.")
     fun isValidMorphTargetBuffer(morphTargetBuffer: MorphTargetBuffer): Boolean
     /** Validate an IndirectLight. @return true if valid. */
     fun isValidIndirectLight(ibl: IndirectLight): Boolean
@@ -376,6 +379,7 @@ expect class Engine {
     /** Validate a Texture. @return true if valid. */
     fun isValidTexture(texture: Texture): Boolean
     /** Validate a Stream. @return true if valid. @throws UnsupportedOperationException on JS — Stream is unbound on web. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — not bound in filament.js.")
     fun isValidStream(stream: Stream): Boolean
     /** Validate a SwapChain. @return true if valid. */
     fun isValidSwapChain(swapChain: SwapChain): Boolean
@@ -416,6 +420,7 @@ expect class Engine {
     fun destroyScene(scene: Scene)
 
     /** Create a Fence for GPU synchronization. @throws UnsupportedOperationException on JS — fences are unbound on web. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — fences are not bound in filament.js.")
     fun createFence(): Fence
     /** Destroy a Fence. */
     fun destroyFence(fence: Fence)
@@ -463,6 +468,7 @@ expect class Engine {
     /** Flush pending GPU commands to the driver (non-blocking). */
     fun flush()
     /** Whether rendering is currently paused. Set to pause or resume rendering. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "state is only tracked locally — filament.js does not bind pause, so it has no effect on rendering.")
     var paused: Boolean
     /** Deprecated no-op method. */
     fun unprotected()

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Fence.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Fence.kt
@@ -3,6 +3,7 @@ package io.github.erkko68.filament
 /**
  * Fence is used to synchronize the application main thread with filament's rendering thread.
  */
+@PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "unusable — Engine.createFence throws; filament.js exposes no GPU/CPU fence API.")
 expect class Fence {
     /**
      * Mode controls the behavior of the command stream when calling wait().

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/LightManager.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/LightManager.kt
@@ -215,6 +215,7 @@ expect class LightManager {
          * @param options ShadowOptions configuration
          * @return This Builder
          */
+        @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "silent no-op — upstream embind registers ShadowOptions with an unregisterable mat4f field, so the binding is unreachable; per-light shadow options stay at Filament's defaults on web.")
         fun shadowOptions(options: ShadowOptions): Builder
 
         /**
@@ -351,6 +352,7 @@ expect class LightManager {
      * @return Number of light components
      * @throws UnsupportedOperationException on JS — getComponentCount is unbound in the web wrapper.
      */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — not bound in filament.js.")
     fun getComponentCount(): Int
 
     /**

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/MaterialInstance.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/MaterialInstance.kt
@@ -98,6 +98,7 @@ expect class MaterialInstance {
      *
      * @return The parent Material. The Material owns all instances created from it.
      */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "getter throws UnsupportedOperationException — filament.js does not expose MaterialInstance.getMaterial.")
     val material: Material
 
     /**

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/MorphTargetBuffer.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/MorphTargetBuffer.kt
@@ -25,6 +25,7 @@ package io.github.erkko68.filament
  *
  * @see RenderableManager
  */
+@PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "Builder.build throws UnsupportedOperationException — the standalone API is unbound in filament.js; gltfio handles glTF morph targets internally.")
 expect class MorphTargetBuffer {
     /**
      * Builder for creating MorphTargetBuffer instances.

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/PlatformGap.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/PlatformGap.kt
@@ -1,0 +1,34 @@
+package io.github.erkko68.filament
+
+/**
+ * Platform buckets used by [PlatformGap]. [WEB] covers both the `js` and `wasmJs` targets
+ * (they share the same `webMain` actuals and the same Filament.js binding surface).
+ */
+enum class FilamentPlatform { ANDROID, IOS, JVM, WEB }
+
+/**
+ * Marks a common API whose platform binding is missing or degraded on the listed platforms.
+ *
+ * The API exists in `commonMain` so shared code compiles everywhere, but the platform `actual`
+ * cannot reach the underlying engine feature — usually because upstream `filament.js`
+ * (embind, `jsbindings.cpp`) does not register it. [behavior] states exactly what the call does
+ * there: throws `UnsupportedOperationException`, is a silent no-op, or returns a placeholder.
+ *
+ * The full per-platform coverage table lives in
+ * [Platform Notes](https://github.com/Erkko68/filament-kmp/blob/main/docs/platform-notes.md).
+ *
+ * @property platforms Platforms on which the binding is missing or degraded.
+ * @property behavior What calling the API does on those platforms.
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+)
+annotation class PlatformGap(
+    val platforms: Array<FilamentPlatform>,
+    val behavior: String,
+)

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/RenderableManager.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/RenderableManager.kt
@@ -131,6 +131,7 @@ expect class RenderableManager {
          * @param count number of vertices to read (for triangles, this should be a multiple of 3)
          * @return Builder reference for chaining calls.
          */
+        @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — filament.js only binds the indexed geometry overloads.")
         fun geometry(index: Int, type: PrimitiveType, vb: VertexBuffer, offset: Int, count: Int): Builder
 
         /**
@@ -141,6 +142,7 @@ expect class RenderableManager {
          * @param vb specifies the vertex buffer, which in turn specifies a set of attributes
          * @return Builder reference for chaining calls.
          */
+        @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — filament.js only binds the indexed geometry overloads.")
         fun geometry(index: Int, type: PrimitiveType, vb: VertexBuffer): Builder
 
         /**
@@ -680,6 +682,7 @@ expect class RenderableManager {
      * @param offset vertex offset in the vertex buffer
      * @param count number of vertices to render
      */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException — filament.js only binds the indexed setGeometryAt overload.")
     fun setGeometryAt(instance: EntityInstance, primitiveIndex: Int, type: PrimitiveType, vb: VertexBuffer, offset: Int, count: Int)
 
     /**

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Renderer.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Renderer.kt
@@ -196,6 +196,7 @@ expect class Renderer {
      * @param srcViewport Source viewport rectangle.
      * @param flags Behavior flags (COMMIT, SET_PRESENTATION_TIME, CLEAR).
      */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "silent no-op — Renderer.copyFrame is not bound in filament.js.")
     fun copyFrame(dstSwapChain: SwapChain, dstViewport: Viewport, srcViewport: Viewport, flags: Int)
 
     /**
@@ -214,6 +215,7 @@ expect class Renderer {
      * @param height Height in pixels.
      * @param buffer Pixel buffer descriptor for the result.
      */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "silent no-op — Renderer.readPixels is not bound in filament.js.")
     fun readPixels(xoffset: Int, yoffset: Int, width: Int, height: Int, buffer: Texture.PixelBufferDescriptor)
 
     /**
@@ -228,6 +230,7 @@ expect class Renderer {
      * @param height Height in pixels.
      * @param buffer Pixel buffer descriptor for the result.
      */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "silent no-op — Renderer.readPixels is not bound in filament.js.")
     fun readPixels(renderTarget: RenderTarget, xoffset: Int, yoffset: Int, width: Int, height: Int, buffer: Texture.PixelBufferDescriptor)
 
     /**

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/SkinningBuffer.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/SkinningBuffer.kt
@@ -14,6 +14,7 @@ package io.github.erkko68.filament
  *
  * @see RenderableManager.setSkinningBuffer
  */
+@PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "unbound in filament.js — Builder.build throws and setBonesAt is a silent no-op; glTF skinning still works through gltfio.")
 expect class SkinningBuffer {
     /**
      * Builder for creating SkinningBuffer instances.

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Stream.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Stream.kt
@@ -39,6 +39,7 @@ package io.github.erkko68.filament
  * @see Texture
  * @see TextureSampler
  */
+@PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws UnsupportedOperationException on construction — Stream is not bound in filament.js; external/native video streams have no web equivalent.")
 expect class Stream {
     /**
      * Indicates the type of stream source.

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/SurfaceOrientation.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/SurfaceOrientation.kt
@@ -53,6 +53,7 @@ expect class SurfaceOrientation {
          * @param stride Byte offset between consecutive tangents. 0 means tightly packed.
          * @return This Builder instance for method chaining.
          */
+        @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "silent no-op — filament.js's extension wrapper exposes no tangents(buffer, stride) entry point.")
         fun tangents(buffer: FloatArray, stride: Int = 0): Builder
 
         /**

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Texture.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/Texture.kt
@@ -459,6 +459,7 @@ expect class Texture {
          * @param engine Engine to query
          * @return true if texture swizzling is supported
          */
+        @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "always returns false — not bound in filament.js.")
         fun isTextureSwizzleSupported(engine: Engine): Boolean
 
         /**

--- a/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/View.kt
+++ b/kotlin/filament/src/commonMain/kotlin/io/github/erkko68/filament/View.kt
@@ -925,6 +925,7 @@ expect class View {
     var renderTarget: RenderTarget?
 
     /** Shadow mapping technique for the whole View ([ShadowType.PCF], VSM, DPCF, PCSS). */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "silent no-op unless the filament.js build binds setShadowType (stock upstream prebuilts do not) — web stays on PCF shadows.")
     var shadowType: ShadowType
 
     /** Variance shadow mapping options; only applies when [shadowType] is [ShadowType.VSM]. */
@@ -943,6 +944,7 @@ expect class View {
     var multiSampleAntiAliasingOptions: MultiSampleAntiAliasingOptions
 
     /** Culls renderables outside the camera frustum. Default: true (disable only for debugging). */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "setter is a silent no-op — setFrustumCullingEnabled is not bound in filament.js; the getter reflects the locally tracked value.")
     var isFrustumCullingEnabled: Boolean
 
     /** Master switch for shadow mapping in this View. Default: true. */

--- a/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/FilamentAsset.kt
+++ b/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/FilamentAsset.kt
@@ -3,6 +3,8 @@ package io.github.erkko68.filament.gltfio
 import io.github.erkko68.filament.Box
 import io.github.erkko68.filament.Engine
 import io.github.erkko68.filament.Entity
+import io.github.erkko68.filament.FilamentPlatform
+import io.github.erkko68.filament.PlatformGap
 
 /**
  * FilamentAsset owns a loaded glTF 2.0 asset and all its Filament objects.
@@ -83,9 +85,11 @@ expect class FilamentAsset {
     fun getEntityCount(): Int
 
     /** Returns the number of instances created from this asset (>= 1 unless detached). */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws at runtime with embind 'unbound types' — the vector return type is unregistered in the web prebuilt.")
     fun getAssetInstanceCount(): Int
 
     /** Returns every [FilamentInstance] created from this asset. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws at runtime with embind 'unbound types' — the vector return type is unregistered in the web prebuilt.")
     fun getAssetInstances(): Array<FilamentInstance>
 
     /**
@@ -103,6 +107,7 @@ expect class FilamentAsset {
     fun getExtras(entity: Entity): String?
 
     /** Gets the morph target names declared on the given entity, in target order. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "returns an empty array — not exposed by filament.js.")
     fun getMorphTargetNames(entity: Entity): Array<String>
 
     /** Gets the URIs of all externally-referenced buffers/textures (to feed [ResourceLoader]). */

--- a/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/FilamentInstance.kt
+++ b/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/FilamentInstance.kt
@@ -1,6 +1,8 @@
 package io.github.erkko68.filament.gltfio
 
 import io.github.erkko68.filament.Box
+import io.github.erkko68.filament.FilamentPlatform
+import io.github.erkko68.filament.PlatformGap
 
 /**
  * FilamentInstance provides access to a hierarchy of entities instanced from a glTF asset.
@@ -80,9 +82,11 @@ expect class FilamentInstance {
     fun detachSkin(skinIndex: Int, target: Int)
 
     /** Gets the number of joints in the skin at [skinIndex]. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "returns 0 — filament.js exposes no joint API.")
     fun getJointCountAt(skinIndex: Int): Int
 
     /** Gets the joint entities of the skin at [skinIndex]. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "returns an empty array — filament.js exposes no joint API.")
     fun getJointsAt(skinIndex: Int): IntArray
 
     /**
@@ -94,6 +98,7 @@ expect class FilamentInstance {
     fun applyMaterialVariant(variantIndex: Int)
 
     /** Gets all material instances of this instance. These are already bound to renderables. */
+    @PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "throws at runtime with embind 'unbound types' — the vector return type is unregistered in the web prebuilt.")
     fun getMaterialInstances(): Array<io.github.erkko68.filament.MaterialInstance>
 
     /** Gets the names of all material variants declared in the asset, in variant-index order. */

--- a/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/MaterialProvider.kt
+++ b/kotlin/gltfio/src/commonMain/kotlin/io/github/erkko68/filament/gltfio/MaterialProvider.kt
@@ -1,6 +1,8 @@
 package io.github.erkko68.filament.gltfio
 
 import io.github.erkko68.filament.Engine
+import io.github.erkko68.filament.FilamentPlatform
+import io.github.erkko68.filament.PlatformGap
 
 /**
  * MaterialProvider supplies materials to glTF assets during loading.
@@ -54,6 +56,7 @@ expect interface MaterialProvider {
  *
  * @see MaterialProvider
  */
+@PlatformGap(platforms = [FilamentPlatform.WEB], behavior = "createMaterialInstance/getMaterial throw — filament.js does not expose the ubershader material provider; use precompiled .filamat materials on web.")
 expect class UbershaderProvider : MaterialProvider {
     /**
      * Create an UbershaderProvider.


### PR DESCRIPTION
Makes the per-platform binding gaps first-class and discoverable:

- New `@PlatformGap(platforms, behavior)` annotation in the core module (`@MustBeDocumented`, binary retention) — the gap shows in the IDE and in the Dokka reference on the affected declaration itself.
- Applied to every real gap, inventoried from the web actuals and `@IgnoreJs` test reasons (all current gaps are web-only, almost all because upstream `filament.js` doesn't bind the function): `Stream`/`SkinningBuffer`/`MorphTargetBuffer`/`Fence`, `Engine` fences + `paused`, `MaterialInstance.getMaterial`, the `LightManager.Builder.shadowOptions` embind no-op, non-indexed geometry overloads, `Renderer` readbacks, the `View.shadowType` PCF lock, gltfio instance/joint/morph-name queries, `UbershaderProvider`, filamat `MaterialBuilder`, `HDRLoader`.
- `docs/platform-notes.md` gains the authoritative **Binding coverage** table (API / behavior on web / workaround), replacing the partly stale bullet list — notably `KTX1Loader.getSphericalHarmonics` *does* work on web now.
- API dumps refreshed: the diff is exactly the new annotation + platform enum, nothing else.

**Stacked on the KDoc sweep PR** (which stacks on #65) — merges last; GitHub retargets automatically.