### PR TITLE
docs: clarify versioning scheme and reframe HexonKMP as a sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-Since `0.2.0`: minor (`0.X.0`) tracks upstream Filament feature releases and may change
-public API pre-1.0; patch (`0.0.X`) is bug fixes only. See
+Since `0.2.0`: minor (`X.Y.0`) tracks upstream Filament feature releases and may change
+public API; patch (`X.Y.Z`) is bug fixes only; a major bump is reserved for maturity
+milestones and very large changes. See
 [README → Versioning & stability](README.md#versioning--stability).
 
 Each entry is one line; click the version link at the bottom for the full diff.
@@ -23,7 +24,7 @@ Each entry is one line; click the version link at the bottom for the full diff.
 - **Test materials now load on every target** (tests): `.filamat` test blobs are base64-embedded into commonTest at build time (`generateEmbeddedMaterials`, sharing the `registerEmbeddedTestResources` build-logic helper with gltfio's `generateEmbeddedGlb`), replacing the JVM-only classpath resource — material/renderable rendering tests now also run on web, iOS, and Android instead of silently skipping.
 
 ### Changed
-- **Dropped the `-beta` suffix** (release): versions are plain `X.Y.Z` from now on — minor bumps track upstream Filament feature releases (this one: 1.72.0 → 1.73.0), patch bumps are fixes only, and `1.0.0` marks API maturity. See [README → Versioning & stability](README.md#versioning--stability).
+- **Dropped the `-beta` suffix** (release): versions are plain `X.Y.Z` from now on — minor bumps track upstream Filament feature releases (this one: 1.72.0 → 1.73.0), patch bumps are fixes only, and a major bump is reserved for API maturity and very large changes. See [README → Versioning & stability](README.md#versioning--stability).
 - **Python is no longer a build dependency** (build): the prebuilt/header/jextract download scripts were ported to pure-JVM Gradle tasks in `build-logic` (commons-compress for tar.gz), keeping the same task names, cache dirs, and version stamping — and making the prebuilt downloads fully version-aware, so bumping `filaVersion` re-extracts automatically. `setup-python` dropped from all CI workflows.
 - **`buildSrc` became the `build-logic` included build** (build): convention-plugin edits no longer invalidate the whole main build's task graph.
 - **Public-API surface is now CI-enforced** (build): binary-compatibility-validator's `apiCheck` guards the JVM ABI of the five published `:kotlin:*` modules against committed `api/` dumps; intentional API changes must ship a regenerated `apiDump`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > **Unofficial project.** This is a community-maintained Kotlin Multiplatform wrapper around [Google's Filament](https://github.com/google/filament). It is not affiliated with, endorsed by, or supported by Google or the Filament team.
 
 > [!NOTE]
-> **Pre-1.0 (`0.2.0`).** Major development and internal repository restructuring are done and the project is on track to stability, but public APIs may still change between minor releases while we track upstream Filament — read the [changelog](CHANGELOG.md) before upgrading. See [Versioning & stability](#versioning--stability). The JVM bindings run on Project Panama (FFM, **requires JDK 22+**).
+> **Current release: `0.2.0`.** Major development and internal repository restructuring are done and the project is stabilizing, but public APIs may still change between minor releases while we track upstream Filament — read the [changelog](CHANGELOG.md) before upgrading. See [Versioning & stability](#versioning--stability). The JVM bindings run on Project Panama (FFM, **requires JDK 22+**).
 
 **Filament KMP** brings the same physically based renderer that powers Android's Filament to **iOS**, **Desktop/JVM**, and **Web (JS & Wasm)**, with first-class **Compose Multiplatform** integration.
 
@@ -88,11 +88,11 @@ All published under `io.github.erkko68.filament`. The Desktop/JVM bindings (Proj
 
 Releases are plain `X.Y.Z` (no pre-release suffixes since `0.2.0`):
 
-- **`0.X.0` (minor)** — each new upstream **Filament feature release** (1.73 → 1.74 → …) ships as a minor bump, together with any wrapper API additions or changes accumulated since the last one. Pre-1.0, breaking wrapper API changes may land here; they are always listed in the [changelog](CHANGELOG.md).
-- **`0.0.X` (patch)** — bug fixes only: upstream Filament point releases (e.g. 1.73.1) and fixes in the wrapper itself. Safe to pick up without reading anything.
-- **`1.0.0` (major)** — will be tagged when the project reaches maturity: a stabilized public API, the known issue backlog worked down, and at least a year of production use behind it. From then on, breaking changes only land in major releases.
+- **`X.Y.0` (minor)** — the normal release channel. Each new upstream **Filament feature release** (1.73 → 1.74 → …) ships as a minor bump, together with any wrapper API additions or changes accumulated since the last one. This is where regular work lands; breaking wrapper API changes may appear here and are always listed in the [changelog](CHANGELOG.md).
+- **`X.Y.Z` (patch)** — bug fixes only: upstream Filament point releases (e.g. 1.73.1) and fixes in the wrapper itself. Safe to pick up without reading anything.
+- **`X.0.0` (major)** — reserved for maturity milestones and very large changes (a stabilized public API, a full architectural rework). Routine upstream tracking never triggers a major bump — expect minor releases to keep flowing for as long as Filament keeps releasing.
 
-All `io.github.erkko68.filament:*` artifacts share one version and must be upgraded together. The project is actively maintained long-term: it tracks upstream Filament releases as they are published (see [docs/upgrading-filament.md](docs/upgrading-filament.md) for the process) and is developed against a real downstream consumer, [HexonKMP](https://github.com/Erkko68/HexonKMP). Larger technical direction — like zero-copy GPU sharing with Compose — lives in the [Roadmap](ROADMAP.md).
+All `io.github.erkko68.filament:*` artifacts share one version and must be upgraded together. The project is actively maintained long-term and tracks upstream Filament releases as they are published (see [docs/upgrading-filament.md](docs/upgrading-filament.md) for the process). Larger technical direction — like zero-copy GPU sharing with Compose — lives in the [Roadmap](ROADMAP.md).
 
 ## API strategy
 
@@ -124,7 +124,7 @@ The web build is also deployed live to **[erkko68.github.io/filament-kmp](https:
 
 ## Showcase
 
-- **[HexonKMP](https://github.com/Erkko68/HexonKMP)** — a Catan-like strategy board game built with Filament KMP, running across platforms from a single codebase. Try the live web demo at **[hexon.biri.es](https://hexon.biri.es)**.
+- **[HexonKMP](https://github.com/Erkko68/HexonKMP)** — a larger sample app: a Catan-like strategy board game built with Filament KMP, running across platforms from a single codebase. Try the live web demo at **[hexon.biri.es](https://hexon.biri.es)**.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,13 +7,13 @@ internal repository restructuring (prebuilt pipeline, vendored web externals, CI
 API-surface enforcement) are done, and the focus shifts to tracking upstream and hardening.
 
 - **Upstream tracking** — each Filament feature release (1.73 → 1.74 → …) is picked up as a
-  `0.X.0` minor release following [docs/upgrading-filament.md](docs/upgrading-filament.md);
-  upstream point releases and wrapper fixes ship as `0.0.X` patches. See
-  [README → Versioning & stability](README.md#versioning--stability) for the full scheme.
-- **Path to `1.0.0`** — tagged when the project reaches maturity: a stabilized public API,
-  the known issue backlog worked down, and at least a year of production use behind it.
-  Until then, minor releases may still adjust public API (always listed in the
-  [changelog](CHANGELOG.md)).
+  minor release following [docs/upgrading-filament.md](docs/upgrading-filament.md);
+  upstream point releases and wrapper fixes ship as patches. Minor releases are the ongoing
+  channel — see [README → Versioning & stability](README.md#versioning--stability).
+- **Path to `1.0.0`** — a major bump is reserved for maturity and very large changes: a
+  stabilized public API and the known issue backlog worked down. It is not tied to any
+  upstream Filament version. Until then, minor releases may still adjust public API (always
+  listed in the [changelog](CHANGELOG.md)).
 - **Known gaps** — per-platform binding gaps are tracked via `@PlatformGap` and the coverage
   table in [Platform Notes](docs/platform-notes.md); web-specific limits come from what
   `filament.js` binds upstream.


### PR DESCRIPTION
Documentation-only change, no code touched.

## Versioning & stability

Reworked the scheme in `README.md`, mirrored in `ROADMAP.md` and the `CHANGELOG.md` header:

- **Minor is the permanent release channel.** Every upstream Filament feature release ships as a minor bump, and that keeps going for as long as Filament keeps releasing.
- **Major is reserved** for maturity milestones and very large changes (stabilized public API, architectural rework). Explicitly noted that routine upstream tracking never triggers one, and that it is not tied to any upstream Filament version.
- Notation switched from `0.X.0` / `0.0.X` to `X.Y.0` / `X.Y.Z` so the docs stay accurate past 1.0.
- The README banner is now "Current release: `0.2.0`" instead of "Pre-1.0", since 1.0 is no longer a milestone on a schedule. Dropped "at least a year of production use behind it" from the roadmap's 1.0 criteria.

## HexonKMP framing

Removed the claim that the project is "developed against a real downstream consumer, HexonKMP" — it is a sample app by the same author, not an external adopter. The Showcase entry keeps the link and live demo but now describes it as such.
