### PR TITLE
fix(compose): make flight camera speed actually settable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Each entry is one line; click the version link at the bottom for the full diff.
 
 ## [Unreleased]
 
+### Fixed
+- **Flight camera speed is finally settable** (`filament-compose`, behavior-breaking): `rememberFlightCameraController` gained `initialMoveSpeed` (default `1f`) and `speedSteps` (default `20`, was upstream's `80`). Filament's `FreeFlightManipulator` computes its speed as `maxMoveSpeed^(wheel/halfSteps)`, which is **1.0 world-unit/s at wheel 0** — so `maxMoveSpeed` alone did nothing until you scrolled, and one scroll notch over 80 steps moved the speed by ~6%, making the wheel feel dead too. The controller now seeds the wheel from `initialMoveSpeed`, carries it across a tuning rebuild, and exposes `FlightCameraController.adjustSpeed(steps)`; `maxMoveSpeed` is documented as what full scroll-up reaches. Scrolling **up** now speeds up (it was inverted relative to the orbit/map zoom convention).
+- **Flight start orientation was off by a factor of 57** (`filament-compose`, behavior-breaking): `rememberFlightCameraController`'s `startPitch`/`startYaw` are documented in degrees but were passed straight to `Manipulator.flightStartOrientation`, which takes radians — non-zero values aimed the camera nowhere near where they said. They are now converted; if you compensated by passing radians, drop the conversion.
+
 ## [0.3.0] — 2026-07-22
 
 ### Added

--- a/docs/compose/README.md
+++ b/docs/compose/README.md
@@ -122,7 +122,7 @@ recompose. **Everything else per-frame is built on it:**
 | `rememberAnimationState` | Playing/blending glTF skeletal animation — the high-level path. Don't hand-roll the timing. |
 | `rememberSceneClock()` | You want elapsed **seconds as a `State<Float>`** to read in composition (orbit a `Group`, pulse a value). Reading it recomposes every frame — that's its whole point, and the one case you *want* a frame to recompose. |
 | `FilamentEffect { onFrame { … } }` | Per-frame work from inside a `rememberFilamentScene` escape hatch, with the `engine`/`scene` in scope. The callback gets the same `FrameInfo`. |
-| `rememberFlightCameraController` | Free-flight camera; it advances itself every frame (no separate loop composable needed). |
+| `rememberFlightCameraController` | Free-flight camera; it advances itself every frame (no separate loop composable needed). Flies at `initialMoveSpeed`; the scroll wheel steps it up to `maxMoveSpeed`. |
 
 And the per-**recomposition** siblings, for completeness:
 

--- a/kotlin/filament-compose/api/jvm/filament-compose.api
+++ b/kotlin/filament-compose/api/jvm/filament-compose.api
@@ -68,6 +68,7 @@ public final class io/github/erkko68/filament/compose/FilamentViewStateKt {
 
 public final class io/github/erkko68/filament/compose/FlightCameraController : io/github/erkko68/filament/compose/CameraController {
 	public static final field $stable I
+	public final fun adjustSpeed (F)V
 	public fun jumpToBookmark (Lio/github/erkko68/filament/utils/Manipulator$Bookmark;)V
 	public fun resetToHome ()V
 	public fun saveBookmark ()Lio/github/erkko68/filament/utils/Manipulator$Bookmark;
@@ -100,7 +101,7 @@ public final class io/github/erkko68/filament/compose/InteractionKt {
 	public static final fun mapGestures (Landroidx/compose/ui/Modifier;Lio/github/erkko68/filament/compose/MapCameraController;)Landroidx/compose/ui/Modifier;
 	public static final fun orbitGestures (Landroidx/compose/ui/Modifier;Lio/github/erkko68/filament/compose/OrbitCameraController;)Landroidx/compose/ui/Modifier;
 	public static final fun pickOnTap (Landroidx/compose/ui/Modifier;Lio/github/erkko68/filament/compose/FilamentViewState;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
-	public static final fun rememberFlightCameraController (Lio/github/erkko68/filament/compose/scene/CameraState;FFFFFFLandroidx/compose/runtime/Composer;II)Lio/github/erkko68/filament/compose/FlightCameraController;
+	public static final fun rememberFlightCameraController (Lio/github/erkko68/filament/compose/scene/CameraState;FFFFIFFFLandroidx/compose/runtime/Composer;II)Lio/github/erkko68/filament/compose/FlightCameraController;
 	public static final fun rememberMapCameraController (Lio/github/erkko68/filament/compose/scene/CameraState;FFFFLandroidx/compose/runtime/Composer;II)Lio/github/erkko68/filament/compose/MapCameraController;
 	public static final fun rememberOrbitCameraController (Lio/github/erkko68/filament/compose/scene/CameraState;FFFZLandroidx/compose/runtime/Composer;II)Lio/github/erkko68/filament/compose/OrbitCameraController;
 }

--- a/kotlin/filament-compose/src/commonMain/kotlin/io/github/erkko68/filament/compose/Interaction.kt
+++ b/kotlin/filament-compose/src/commonMain/kotlin/io/github/erkko68/filament/compose/Interaction.kt
@@ -26,6 +26,8 @@ import io.github.erkko68.filament.compose.scene.CameraState
 import io.github.erkko68.filament.compose.scene.Direction
 import io.github.erkko68.filament.compose.scene.Position
 import io.github.erkko68.filament.utils.Manipulator
+import io.github.erkko68.filament.utils.radians
+import kotlin.math.ln
 
 // ── Shared internals ──────────────────────────────────────────────────────────
 
@@ -312,8 +314,19 @@ class FlightCameraController internal constructor(
     // Owned here so [Modifier.flightGestures] can stay a plain (non-composable) modifier like
     // the orbit/map ones; the keyboard focus is requested once from rememberFlightCameraController.
     internal val focusRequester: FocusRequester,
+    // Absolute wheel position, shared across tuning rebuilds so the chosen speed survives one.
+    private val speedWheel: FloatArray,
+    private val speedSteps: Int,
 ) : CameraController {
     override fun setViewport(width: Int, height: Int) = manipulator.setViewport(width, height)
+
+    /** Step the movement speed along the `initialMoveSpeed`…`maxMoveSpeed` curve; one unit of
+     *  [steps] is one of `speedSteps`. Driven by the scroll wheel in [Modifier.flightGestures]. */
+    fun adjustSpeed(steps: Float) {
+        val half = speedSteps / 2f
+        speedWheel[0] = (speedWheel[0] + steps).coerceIn(-half, half)
+        manipulator.scroll(0, 0, steps) // clamps the same way internally
+    }
 
     /** Advance the camera simulation by [deltaTime] seconds. Flight-only; driven automatically
      *  per frame by [rememberFlightCameraController], so callers rarely call it directly. */
@@ -335,15 +348,21 @@ class FlightCameraController internal constructor(
  * The manipulator's start position is taken from [cameraState.eye] at creation time.
  *
  * The tuning parameters are reactive — changing them at runtime rebuilds the manipulator
- * while keeping the current camera pose, so nothing jumps; [startPitch]/[startYaw] only
- * define the initial (and [resetToHome][FlightCameraController.resetToHome]) orientation.
+ * while keeping the current camera pose and the current scroll-wheel speed, so nothing jumps;
+ * [startPitch]/[startYaw] only define the initial (and
+ * [resetToHome][FlightCameraController.resetToHome]) orientation.
  *
- * @param startPitch     Initial pitch in degrees (positive = look up).
- * @param startYaw       Initial yaw in degrees.
- * @param maxMoveSpeed   Maximum movement speed in world units per second.
- * @param moveDamping    Movement damping (higher = snappier stop).
- * @param panSpeedX      Mouse-look horizontal sensitivity.
- * @param panSpeedY      Mouse-look vertical sensitivity.
+ * Speed sits on an exponential curve spanning [speedSteps] scroll notches: the camera starts at
+ * [initialMoveSpeed], full scroll-up reaches [maxMoveSpeed], full scroll-down `1 / maxMoveSpeed`.
+ *
+ * @param startPitch       Initial pitch in degrees (positive = look up).
+ * @param startYaw         Initial yaw in degrees.
+ * @param maxMoveSpeed     Movement speed in world units per second at full scroll-up.
+ * @param initialMoveSpeed Movement speed before any scrolling; must be > 0.
+ * @param speedSteps       Scroll notches spanning the whole speed range (fewer = coarser steps).
+ * @param moveDamping      Movement damping (higher = snappier stop).
+ * @param panSpeedX        Mouse-look horizontal sensitivity.
+ * @param panSpeedY        Mouse-look vertical sensitivity.
  */
 @Composable
 fun rememberFlightCameraController(
@@ -351,26 +370,47 @@ fun rememberFlightCameraController(
     startPitch: Float = 0f,
     startYaw: Float = 0f,
     maxMoveSpeed: Float = 10f,
+    initialMoveSpeed: Float = 1f,
+    speedSteps: Int = 20,
     moveDamping: Float = 15f,
     panSpeedX: Float = 0.01f,
     panSpeedY: Float = 0.01f,
 ): FlightCameraController {
     val focusRequester = remember { FocusRequester() }
     val previous = remember(cameraState) { arrayOfNulls<Manipulator>(1) }
-    val state = remember(cameraState, startPitch, startYaw, maxMoveSpeed, moveDamping, panSpeedX, panSpeedY) {
+    // Absolute wheel position; seeded from initialMoveSpeed, then owned by adjustSpeed().
+    val speedWheel = remember(cameraState) { FloatArray(1) { Float.NaN } }
+    val state = remember(
+        cameraState, startPitch, startYaw,
+        maxMoveSpeed, initialMoveSpeed, speedSteps, moveDamping, panSpeedX, panSpeedY,
+    ) {
         val eye = cameraState.eye
         val manipulator = Manipulator.Builder()
             .flightStartPosition(eye.x, eye.y, eye.z)
-            .flightStartOrientation(startPitch, startYaw)
+            .flightStartOrientation(radians(startPitch), radians(startYaw))
             .flightMaxMoveSpeed(maxMoveSpeed)
+            .flightSpeedSteps(speedSteps)
             .flightMoveDamping(moveDamping)
             .flightPanSpeed(panSpeedX, panSpeedY)
             .build(Manipulator.Mode.FLIGHT)
+        // The manipulator's speed is maxMoveSpeed^(wheel/half), i.e. always 1.0 at wheel 0 —
+        // maxMoveSpeed alone has no effect until you scroll. Seed the wheel so the camera
+        // actually starts at initialMoveSpeed, and re-apply it after a tuning rebuild.
+        val half = speedSteps / 2f
+        if (speedWheel[0].isNaN()) {
+            val ratio = if (maxMoveSpeed > 0f && maxMoveSpeed != 1f) {
+                ln(initialMoveSpeed.coerceAtLeast(1e-6f)) / ln(maxMoveSpeed)
+            } else 0f
+            speedWheel[0] = (half * ratio).coerceIn(-half, half)
+        }
+        speedWheel[0] = speedWheel[0].coerceIn(-half, half) // speedSteps may have changed
+        manipulator.scroll(0, 0, speedWheel[0])
         // Carry the current pose across a tuning rebuild so the camera doesn't move (same as
         // orbit/map); without this, orientation would snap back to startPitch/startYaw.
         previous[0]?.let { manipulator.jumpToBookmark(it.getCurrentBookmark()) }
         previous[0] = manipulator
-        FlightCameraController(manipulator, cameraState, focusRequester).also { it.sync() }
+        FlightCameraController(manipulator, cameraState, focusRequester, speedWheel, speedSteps)
+            .also { it.sync() }
     }
     DisposableEffect(state) { onDispose { state.manipulator.destroy() } }
     // Self-driving: advance the flight simulation every frame so callers never need a separate loop.
@@ -393,7 +433,7 @@ fun rememberFlightCameraController(
  * | D / Arrow Right    | Strafe right     |
  * | E / Space          | Move up          |
  * | Q / Shift          | Move down        |
- * | Scroll wheel       | Change speed     |
+ * | Scroll up / down   | Faster / slower  |
  */
 fun Modifier.flightGestures(controller: FlightCameraController): Modifier =
     this
@@ -434,17 +474,13 @@ fun Modifier.flightGestures(controller: FlightCameraController): Modifier =
             }
         }
         .pointerInput(controller) {
-            // Scroll to adjust movement speed
+            // Scroll to adjust movement speed. Scrolling up (negative delta) speeds up.
             awaitPointerEventScope {
                 while (true) {
                     val event = awaitPointerEvent()
                     if (event.type == PointerEventType.Scroll) {
                         val change = event.changes.firstOrNull() ?: continue
-                        controller.manipulator.scroll(
-                            change.position.x.toInt(),
-                            change.position.y.toInt(),
-                            change.scrollDelta.y,
-                        )
+                        controller.adjustSpeed(-change.scrollDelta.y)
                         event.changes.forEach { it.consume() }
                     }
                 }

--- a/kotlin/filament-compose/src/commonTest/kotlin/io/github/erkko68/filament/compose/InteractionTest.kt
+++ b/kotlin/filament-compose/src/commonTest/kotlin/io/github/erkko68/filament/compose/InteractionTest.kt
@@ -1,5 +1,6 @@
 package io.github.erkko68.filament.compose
 
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import io.github.erkko68.filament.compose.scene.CameraState
 import io.github.erkko68.filament.compose.scene.Direction
@@ -7,6 +8,7 @@ import io.github.erkko68.filament.compose.scene.Exposure
 import io.github.erkko68.filament.compose.scene.Position
 import io.github.erkko68.filament.compose.scene.Projection
 import io.github.erkko68.filament.compose.testutils.ComposeTestFixture
+import io.github.erkko68.filament.compose.testutils.SetSceneContent
 import io.github.erkko68.filament.compose.testutils.withFilamentScene
 import io.github.erkko68.filament.utils.Float2
 import io.github.erkko68.filament.utils.Manipulator
@@ -82,55 +84,66 @@ class InteractionTest : ComposeTestFixture() {
         }
     }
 
-    // Undamped so the upstream mEyeVelocity read-before-write (see above) can't bite: with
-    // moveDamping = 0 the velocity is assigned, not accumulated.
+    /**
+     * Mounts a fresh flight controller at the origin and flies FORWARD for one simulated second,
+     * returning the distance covered (= the effective move speed in units/s).
+     *
+     * Undamped so the upstream mEyeVelocity read-before-write (see above) can't bite: with
+     * moveDamping = 0 the velocity is assigned, not accumulated. Takes the harness's `setContent`
+     * instead of opening its own scene: `withFilamentScene` returns a `TestResult` that only
+     * completes asynchronously on web, so a caller-side harness would read the camera before the
+     * body ever ran and report a distance of 0 on js/wasm.
+     */
     @OptIn(ExperimentalTestApi::class)
-    private fun distanceFlown(
+    private fun ComposeUiTest.flyForOneSecond(
+        setContent: SetSceneContent,
         maxMoveSpeed: Float,
         initialMoveSpeed: Float,
         scrollSteps: Float = 0f,
     ): Float {
         val cam = newCameraState(Position(0f, 0f, 0f))
-        lateinit var state: FlightCameraController
-        var flown = 0f
-        withFilamentScene(engine, scene) { setContent ->
-            setContent {
-                state = rememberFlightCameraController(
-                    cam,
-                    maxMoveSpeed = maxMoveSpeed,
-                    initialMoveSpeed = initialMoveSpeed,
-                    moveDamping = 0f,
-                )
-            }
-            waitForIdle()
-            mainClock.advanceTimeByFrame()
-            if (scrollSteps != 0f) state.adjustSpeed(scrollSteps)
-            state.manipulator.keyDown(Manipulator.Key.FORWARD)
-            repeat(10) { state.update(0.1f) } // 1 second of flight
-            state.manipulator.keyUp(Manipulator.Key.FORWARD)
-            flown = cam.eyeDistanceTo(0f, 0f, 0f)
+        lateinit var controller: FlightCameraController
+        setContent {
+            controller = rememberFlightCameraController(
+                cam,
+                maxMoveSpeed = maxMoveSpeed,
+                initialMoveSpeed = initialMoveSpeed,
+                moveDamping = 0f,
+            )
         }
-        return flown
+        waitForIdle()
+        mainClock.advanceTimeByFrame() // mount + first (no-key) OnFrame tick; pose stays at start
+        if (scrollSteps != 0f) controller.adjustSpeed(scrollSteps)
+        controller.manipulator.keyDown(Manipulator.Key.FORWARD)
+        repeat(10) { controller.update(0.1f) } // 1 second of flight
+        controller.manipulator.keyUp(Manipulator.Key.FORWARD)
+        return cam.eyeDistanceTo(0f, 0f, 0f)
     }
 
     /** initialMoveSpeed is the speed the camera actually flies at — before this, the manipulator
      *  always started at 1 unit/s no matter what maxMoveSpeed said. */
+    @OptIn(ExperimentalTestApi::class)
     @Test
-    fun flightInitialMoveSpeedSetsActualSpeed() {
-        assertEquals(1f, distanceFlown(maxMoveSpeed = 10f, initialMoveSpeed = 1f), 0.05f)
-        assertEquals(4f, distanceFlown(maxMoveSpeed = 10f, initialMoveSpeed = 4f), 0.2f)
-        // maxMoveSpeed is only the ceiling of the scroll curve; it must not change the start speed.
-        assertEquals(4f, distanceFlown(maxMoveSpeed = 100f, initialMoveSpeed = 4f), 0.2f)
+    fun flightInitialMoveSpeedSetsActualSpeed() = run {
+        withFilamentScene(engine, scene) { setContent ->
+            assertEquals(1f, flyForOneSecond(setContent, maxMoveSpeed = 10f, initialMoveSpeed = 1f), 0.05f)
+            assertEquals(4f, flyForOneSecond(setContent, maxMoveSpeed = 10f, initialMoveSpeed = 4f), 0.2f)
+            // maxMoveSpeed is only the ceiling of the scroll curve; it must not move the start speed.
+            assertEquals(4f, flyForOneSecond(setContent, maxMoveSpeed = 100f, initialMoveSpeed = 4f), 0.2f)
+        }
     }
 
     /** Scrolling up speeds the camera up, and reaches maxMoveSpeed at the top of the curve. */
+    @OptIn(ExperimentalTestApi::class)
     @Test
-    fun flightScrollAdjustsSpeedUpToMax() {
-        val base = distanceFlown(maxMoveSpeed = 10f, initialMoveSpeed = 1f)
-        val faster = distanceFlown(maxMoveSpeed = 10f, initialMoveSpeed = 1f, scrollSteps = 5f)
-        assertTrue(faster > base * 1.5f, "scrolling up should noticeably speed the camera up")
-        // speedSteps defaults to 20, so +10 notches from the 1 u/s midpoint tops out at maxMoveSpeed.
-        assertEquals(10f, distanceFlown(10f, 1f, scrollSteps = 10f), 0.5f)
-        assertEquals(10f, distanceFlown(10f, 1f, scrollSteps = 50f), 0.5f) // clamped
+    fun flightScrollAdjustsSpeedUpToMax() = run {
+        withFilamentScene(engine, scene) { setContent ->
+            val base = flyForOneSecond(setContent, maxMoveSpeed = 10f, initialMoveSpeed = 1f)
+            val faster = flyForOneSecond(setContent, maxMoveSpeed = 10f, initialMoveSpeed = 1f, scrollSteps = 5f)
+            assertTrue(faster > base * 1.5f, "scrolling up should noticeably speed the camera up")
+            // speedSteps defaults to 20, so +10 notches from the 1 u/s midpoint tops out at maxMoveSpeed.
+            assertEquals(10f, flyForOneSecond(setContent, 10f, 1f, scrollSteps = 10f), 0.5f)
+            assertEquals(10f, flyForOneSecond(setContent, 10f, 1f, scrollSteps = 50f), 0.5f) // clamped
+        }
     }
 }

--- a/kotlin/filament-compose/src/commonTest/kotlin/io/github/erkko68/filament/compose/InteractionTest.kt
+++ b/kotlin/filament-compose/src/commonTest/kotlin/io/github/erkko68/filament/compose/InteractionTest.kt
@@ -81,4 +81,56 @@ class InteractionTest : ComposeTestFixture() {
             assertEquals(0f, cam.eyeDistanceTo(0f, 0f, 5f), 1e-2f)
         }
     }
+
+    // Undamped so the upstream mEyeVelocity read-before-write (see above) can't bite: with
+    // moveDamping = 0 the velocity is assigned, not accumulated.
+    @OptIn(ExperimentalTestApi::class)
+    private fun distanceFlown(
+        maxMoveSpeed: Float,
+        initialMoveSpeed: Float,
+        scrollSteps: Float = 0f,
+    ): Float {
+        val cam = newCameraState(Position(0f, 0f, 0f))
+        lateinit var state: FlightCameraController
+        var flown = 0f
+        withFilamentScene(engine, scene) { setContent ->
+            setContent {
+                state = rememberFlightCameraController(
+                    cam,
+                    maxMoveSpeed = maxMoveSpeed,
+                    initialMoveSpeed = initialMoveSpeed,
+                    moveDamping = 0f,
+                )
+            }
+            waitForIdle()
+            mainClock.advanceTimeByFrame()
+            if (scrollSteps != 0f) state.adjustSpeed(scrollSteps)
+            state.manipulator.keyDown(Manipulator.Key.FORWARD)
+            repeat(10) { state.update(0.1f) } // 1 second of flight
+            state.manipulator.keyUp(Manipulator.Key.FORWARD)
+            flown = cam.eyeDistanceTo(0f, 0f, 0f)
+        }
+        return flown
+    }
+
+    /** initialMoveSpeed is the speed the camera actually flies at — before this, the manipulator
+     *  always started at 1 unit/s no matter what maxMoveSpeed said. */
+    @Test
+    fun flightInitialMoveSpeedSetsActualSpeed() {
+        assertEquals(1f, distanceFlown(maxMoveSpeed = 10f, initialMoveSpeed = 1f), 0.05f)
+        assertEquals(4f, distanceFlown(maxMoveSpeed = 10f, initialMoveSpeed = 4f), 0.2f)
+        // maxMoveSpeed is only the ceiling of the scroll curve; it must not change the start speed.
+        assertEquals(4f, distanceFlown(maxMoveSpeed = 100f, initialMoveSpeed = 4f), 0.2f)
+    }
+
+    /** Scrolling up speeds the camera up, and reaches maxMoveSpeed at the top of the curve. */
+    @Test
+    fun flightScrollAdjustsSpeedUpToMax() {
+        val base = distanceFlown(maxMoveSpeed = 10f, initialMoveSpeed = 1f)
+        val faster = distanceFlown(maxMoveSpeed = 10f, initialMoveSpeed = 1f, scrollSteps = 5f)
+        assertTrue(faster > base * 1.5f, "scrolling up should noticeably speed the camera up")
+        // speedSteps defaults to 20, so +10 notches from the 1 u/s midpoint tops out at maxMoveSpeed.
+        assertEquals(10f, distanceFlown(10f, 1f, scrollSteps = 10f), 0.5f)
+        assertEquals(10f, distanceFlown(10f, 1f, scrollSteps = 50f), 0.5f) // clamped
+    }
 }


### PR DESCRIPTION
## Problem

`rememberFlightCameraController(maxMoveSpeed = …)` had no effect. Filament's `FreeFlightManipulator` computes the speed it integrates as:

```
moveSpeed = maxMoveSpeed^((scrollWheel + half) / half - 1)
```

`scrollWheel` starts at 0, so the exponent is 0 and **the speed is literally `1.0` world-unit/s at startup regardless of `maxMoveSpeed`** — 10, 1000 and 1.0001 all fly identically. `maxMoveSpeed` is only the base of a curve you have to scroll into.

The escape hatch was broken too: `flightGestures` forwarded raw `scrollDelta.y` (≈1 per notch) into the upstream default of 80 steps, so one notch changed speed by `10^(1/40)` ≈ 1.06× — ~40 notches to reach the top, which reads as "scrolling does nothing". `flightSpeedSteps` wasn't exposed on the Compose API either.

Separately, `startPitch`/`startYaw` are documented in **degrees** but were passed straight to `Manipulator.flightStartOrientation`, which takes **radians**.

## Changes

- **`initialMoveSpeed`** (default `1f`, preserving today's effective speed): the controller seeds the manipulator's wheel to `half * ln(initial)/ln(max)` so the camera flies at the requested speed from the first frame. `maxMoveSpeed` keeps its name and is now documented as what full scroll-up reaches.
- **`speedSteps`** (default `20`, down from upstream's `80`) is exposed, so a notch is a meaningful step (~1.26×) instead of ~1.06×.
- **`FlightCameraController.adjustSpeed(steps)`** — public, used by `flightGestures`. The wheel position lives outside the `remember` block, so a tuning-parameter rebuild no longer resets the speed the user picked (it already carried the pose).
- **Scroll direction fixed**: scroll up now speeds up, matching the scroll-up-zooms-in convention `orbitGestures`/`mapGestures` already follow.
- **`startPitch`/`startYaw` converted from degrees to radians.**

## Tests

Two new tests in `InteractionTest` running against the real native manipulator (NOOP fixture), undamped so the upstream uninitialized-`mEyeVelocity` flakiness that `@Ignore`s the neighbouring test can't bite:

- `flightInitialMoveSpeedSetsActualSpeed` — flying forward for 1s covers `initialMoveSpeed` units, and changing `maxMoveSpeed` alone doesn't change it.
- `flightScrollAdjustsSpeedUpToMax` — scrolling up speeds the camera up, tops out at exactly `maxMoveSpeed`, and clamps beyond.

Full `:kotlin:filament-compose:jvmTest` green; `apiDump` regenerated; JS + metadata targets compile.

## Behavior-breaking

Callers who compensated for either bug — passing radians to `startPitch`/`startYaw`, or relying on scroll-down meaning faster — need to drop the compensation. Both are called out in the CHANGELOG.