### PR TITLE
test: retry beginFrame before blaming the readback

### DIFF
--- a/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/RendererRenderingTest.kt
+++ b/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/RendererRenderingTest.kt
@@ -42,10 +42,19 @@ class RendererRenderingTest : RenderingTestFixture() {
             readbackDone.done = true
         }
 
-        if (renderer.beginFrame(swapChain, 0L)) {
-            renderer.render(view)
-            renderer.readPixels(0, 0, w, h, pbd)
-            renderer.endFrame()
+        // beginFrame may skip a frame while the backend warms up (a cold software-GL
+        // emulator does), and a skipped frame never issues the readPixels — so retry it
+        // rather than let the pump below blame the readback for a frame that never ran.
+        var began = false
+        var frameTries = 0
+        while (!began && frameTries++ < 10) {
+            began = renderer.beginFrame(swapChain, 0L)
+            if (began) {
+                renderer.render(view)
+                renderer.readPixels(0, 0, w, h, pbd)
+                renderer.endFrame()
+            }
+            engine.flushAndWait()
         }
         // Pump until the readback callback fires (it's async on GLES backends).
         var tries = 0
@@ -54,6 +63,7 @@ class RendererRenderingTest : RenderingTestFixture() {
         // readPixels is a no-op on web (not bound in jsbindings.cpp); everywhere else
         // the readback must actually land — a silent skip here verifies nothing.
         if (TestEnv.target != TestTarget.JS) {
+            assertTrue(began, "beginFrame never accepted a frame in $frameTries tries")
             assertTrue(readbackDone.done, "readPixels callback never fired")
             assertTrue(pixels.any { it.toInt() != 0 }, "readPixels delivered an all-zero buffer")
         }

--- a/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/testutils/FrameProbe.kt
+++ b/kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/testutils/FrameProbe.kt
@@ -82,10 +82,18 @@ class FrameProbe(private val engine: Engine, val width: Int = 64, val height: In
         val pbd = Texture.PixelBufferDescriptor(pixels, pixels.size, Texture.Format.RGBA, Texture.Type.UBYTE) {
             readbackDone.done = true
         }
-        if (renderer.beginFrame(swapChain, 0L)) {
-            renderer.render(view)
-            renderer.readPixels(0, 0, width, height, pbd)
-            renderer.endFrame()
+        // A skipped beginFrame never issues the readPixels, so retry it — otherwise a
+        // frame the backend declined comes back as "the readback never landed".
+        var began = false
+        var frameTries = 0
+        while (!began && frameTries++ < 10) {
+            began = renderer.beginFrame(swapChain, 0L)
+            if (began) {
+                renderer.render(view)
+                renderer.readPixels(0, 0, width, height, pbd)
+                renderer.endFrame()
+            }
+            engine.flushAndWait()
         }
         var tries = 0
         while (!readbackDone.done && tries++ < 20) engine.flushAndWait()


### PR DESCRIPTION
## Why

`RendererRenderingTest.testBeginEndFrameAndReadPixels` failed on the CI emulator (seen on #112, which touches no Kotlin at all) with:

```
java.lang.AssertionError: readPixels callback never fired
```

That message can't distinguish the two ways to reach it:

1. the readback genuinely never landed, or
2. `beginFrame` skipped the frame — in which case `readPixels` was never issued, and the 20-iteration `flushAndWait` pump underneath it was waiting for a callback that could never come.

The test took a **single cold `beginFrame`** with no warm-up frames, which makes (2) plausible on a slow software-GL emulator (CI runs `-gpu swiftshader_indirect`). It's also the only readback test without warm-up — `FrameProbe.renderAndRead` renders three frames first, which is consistent with the other GPU tests passing on the same emulator run (1 failure out of 99).

## Change

Both call sites retry `beginFrame` (bounded at 10) rather than taking one attempt, and the test asserts on `began` separately:

```kotlin
assertTrue(began, "beginFrame never accepted a frame in $frameTries tries")
assertTrue(readbackDone.done, "readPixels callback never fired")
```

`FrameProbe.renderAndRead` gets the same retry — its warm-up frames make it far less exposed, but the hole on its readback frame is identical, and it silently returns `null` for it.

## Honest caveat

**I could not reproduce the failure locally.** Six runs of the *unmodified* suite against an emulator booted with CI's exact `-gpu swiftshader_indirect` were all green. So the skipped-frame cause is a hypothesis, not a confirmed diagnosis, and this PR may not be the fix.

What it does guarantee is that the next occurrence is conclusive: whichever assertion fires names the failing half. That seemed worth more than another blind rerun.

## Verification

Local emulator (`Pixel_9_Pro`, `-gpu swiftshader_indirect`, SwiftShader/ANGLE confirmed via SurfaceFlinger), with the change applied:

| Module | Result |
| :--- | :--- |
| `:kotlin:filament` | 99/99 |
| `:kotlin:filament-compose` | 86/86 |
| `:kotlin:gltfio` | 34/34 |

Plus `:kotlin:filament:jvmTest` (Metal) for `RendererRenderingTest` + `FrameSemanticsTest`, which exercise the same two loops.