### PR TITLE
fix(web): clear the engine canvas each frame

### DIFF
--- a/kotlin/filament-compose/src/webMain/kotlin/io/github/erkko68/filament/compose/internal/WebViewCompositor.kt
+++ b/kotlin/filament-compose/src/webMain/kotlin/io/github/erkko68/filament/compose/internal/WebViewCompositor.kt
@@ -39,7 +39,14 @@ internal class WebViewCompositor private constructor(private val engine: Engine)
 
     private val canvas: HTMLCanvasElement = engine.jsCanvas
         ?: error("WebViewCompositor requires an Engine created with a canvas")
-    private val renderer: Renderer = engine.createRenderer()
+    // The engine canvas is offscreen, so the browser's implicit post-composite clear may never run
+    // (it doesn't on Android Chrome) and frames accumulate. Clear it ourselves every beginFrame.
+    private val renderer: Renderer = engine.createRenderer().apply {
+        clearOptions = Renderer.ClearOptions().apply {
+            clearColor = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
+            clear = true
+        }
+    }
     private val entries = ArrayList<Entry>()
     private var swapChain: SwapChain? = null
     private var rafId: Int = 0


### PR DESCRIPTION
`WebViewCompositor` creates its own `Renderer` and left Filament's default `ClearOptions` (`clear = false`) in place, so nothing ever cleared the shared WebGL canvas — it relied on the browser's implicit post-composite clear of the drawing buffer.

That clear only runs when the canvas is actually composited. The engine canvas is parked offscreen at `left: -9999px` (`Engine.web.kt`), which Android Chrome never composites, so the buffer is never cleared and frames pile up on top of each other. Desktop Chrome happens to composite it, which is why it looked fine there.

Fixed by clearing to transparent black at `beginFrame`. The clear is unconditional rather than gated on transparency — opaque views write alpha 1 across their whole viewport anyway, and the compositor's single renderer serves every view, so a per-view clear isn't expressible.

Note that `FilamentView` sets `clearOptions` on its own per-view renderer, which is unused on web; that path is unaffected on the other platforms.