### PR TITLE
build(compose): trim 12.6 MB from the Maven Central deployment

### DIFF
--- a/kotlin/filament-compose/build.gradle.kts
+++ b/kotlin/filament-compose/build.gradle.kts
@@ -124,3 +124,21 @@ kotlin {
         }
     }
 }
+
+// ── Published-artifact size trimming (Maven Central deployment bundle cap) ────
+// Two payloads get duplicated across all seven per-target publications and dominate
+// the deployment bundle. Neither is useful to a consumer.
+
+// 1. EmbeddedMaterials.kt is 3.3 MB of generated base64. Seven sources jars carry it.
+// KMP sources jars are org.gradle.jvm.tasks.Jar, not the bundling.Jar that `Jar` resolves to.
+tasks.withType<org.gradle.jvm.tasks.Jar>().matching { it.name.endsWith("SourcesJar") }.configureEach {
+    exclude("**/EmbeddedMaterials.kt")
+}
+
+// 2. The Compose plugin stages the skiko web runtime (9.8 MB, mostly skiko.wasm) into
+//    jsMain resources for app bundling, and Kotlin/JS packs resources into the klib.
+//    Consumer apps unpack their own copy. jsTest keeps its (the plugin stages that
+//    compilation's resources separately), so Karma still serves skiko.
+tasks.named<ProcessResources>("jsProcessResources") {
+    exclude("skiko.wasm", "skiko.mjs", "skikod8.mjs", "js-reexport-symbols.mjs")
+}


### PR DESCRIPTION
Sonatype Central caps a deployment bundle at 80 MB. Measured `0.3.1` at **80.40 MB** across 43 modules (both the `io.github.erkko68.filament` and `io.github.erkko68.filament-ffm` groups), and the FFM native runtime jars added since then push it over.

Two payloads in `:kotlin:filament-compose` are duplicated across all seven per-target publications and are useless to consumers.

| | before | after |
|---|---|---|
| sources jar (× 7 publications) | 1.43 MB | 93 KB |
| `filament-compose-js` klib | 5.03 MB | 1.80 MB |
| **deployment total** | **80.40 MB** | **~67.8 MB** |

### 1. `EmbeddedMaterials.kt` out of the sources jars

The generated file is 3.3 MB of base64 — the `.filamat` blobs `generateEmbeddedMaterials` encodes into `commonMain`. Every one of the seven sources jars carries it.

Note the type: KMP sources jars are `org.gradle.jvm.tasks.Jar`, not the `org.gradle.api.tasks.bundling.Jar` that a bare `Jar` resolves to in a `.kts` script, so `tasks.withType<Jar>()` silently matches nothing.

### 2. skiko web runtime out of the js klib

The Compose plugin stages the skiko web runtime (9.8 MB, mostly `skiko.wasm`) into `jsMain` resources so an application can bundle it, and Kotlin/JS packs a compilation's resources into its klib — so a *library* ends up publishing skiko too.

Consumer apps unpack their own copy from their own Compose plugin; verified by building `samples/webApp`, which still emits the 8.65 MB skiko wasm. `jsTest` is untouched because the plugin stages that compilation's resources separately, so Karma still serves skiko.

### Scope

No API or runtime behaviour change. Verification was `samples/webApp:jsBrowserDistribution` plus inspecting `jsTestProcessResources` output — the full js/wasm browser suite has not been run locally, and per prior experience those tasks can report success on a partial run, so CI there is worth reading via the XML counts.

### Not in this PR

- **Per-target Compose materials (~6 MB).** `matc -p all -a all` is 2587 KB, but no target needs half of it: iOS `-p mobile -a metal` 348 KB, js/wasm `-p mobile -a opengl` 289 KB, android `-p mobile -a opengl -a vulkan` 1012 KB, jvm `-p desktop -a all` 1360 KB. Costs an `expect object EmbeddedMaterials` plus four committed blob sets. Deferred — the headroom here is enough.
- **xz-compressing the FFM natives (~5.6 MB).** `xz -6` gets the dylib to 3.65 MB vs deflate's 5.04 MB, but it means a permanent `org.tukaani:xz` dependency on every JVM consumer.

Dead ends, measured, so nobody re-chases them: `strip -x -S` on the embedded `.a` archives or on `libfilament-c` (~1%, already stripped; `-dead_strip`/`--gc-sections` already on), `matc -Os` (*larger*: 2587 → 2608 KB), `matc -l 1/2/3` (identical), empty javadoc jars (already done).