### PR TITLE
docs: document using the engine without Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Filament KMP
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.erkko68.filament/filament-compose?label=Maven%20Central&color=blue)](https://central.sonatype.com/namespace/io.github.erkko68.filament)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.md)
 [![Filament](https://img.shields.io/badge/Filament-1.75.0-orange)](https://github.com/google/filament)
 [![Kotlin](https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin)](https://kotlinlang.org/docs/multiplatform.html)
 [![Compose Multiplatform](https://img.shields.io/badge/Compose-Multiplatform-4285F4?logo=jetpackcompose)](https://www.jetbrains.com/lp/compose-multiplatform/)
@@ -12,11 +12,10 @@
 [![iOS](https://github.com/Erkko68/filament-kmp/actions/workflows/status-ios.yml/badge.svg?branch=main)](https://github.com/Erkko68/filament-kmp/actions/workflows/status-ios.yml)
 [![Android](https://github.com/Erkko68/filament-kmp/actions/workflows/status-android.yml/badge.svg?branch=main)](https://github.com/Erkko68/filament-kmp/actions/workflows/status-android.yml)
 
+**Filament KMP** brings the same physically based renderer that powers Android's Filament to **iOS**, **Desktop/JVM**, and **Web (JS & Wasm)** — as a plain Kotlin Multiplatform library, with an optional **Compose Multiplatform** layer on top.
+
 > [!NOTE]
 > **Unofficial project.** This is a community-maintained Kotlin Multiplatform wrapper around [Google's Filament](https://github.com/google/filament). It is not affiliated with, endorsed by, or supported by Google or the Filament team.
-
-
-**Filament KMP** brings the same physically based renderer that powers Android's Filament to **iOS**, **Desktop/JVM**, and **Web (JS & Wasm)**, with first-class **Compose Multiplatform** integration.
 
 <img src="docs/images/platforms-hero.png" alt="The same scene rendering on Android, iOS, Desktop and Web" width="800"/>
 
@@ -33,6 +32,21 @@ FilamentSceneView(
 ```
 
 The world is declared in the content lambda; the viewport's look is configured by value. Need several cameras over one world? Hoist the scene with `rememberFilamentScene { … }` and feed it to multiple `FilamentView`s.
+
+**Not using Compose?** `filament`, `gltfio`, `filament-utils` and `filamat` are plain Kotlin bindings with no Compose dependency — drive `Engine` / `Renderer` / `SwapChain` yourself against your own `SurfaceView`, `CAMetalLayer`, GLFW window or `<canvas>`, or render headless and read the pixels back:
+
+```kotlin
+val engine    = Engine.create()
+val swapChain = engine.createSwapChain(NativeSurface(myNativeWindow))
+val renderer  = engine.createRenderer()
+
+if (renderer.beginFrame(swapChain, frameTimeNanos)) {
+    renderer.render(view)
+    renderer.endFrame()
+}
+```
+
+See **[Using the Engine Without Compose](docs/engine.md)**.
 
 ## Platform support
 
@@ -62,19 +76,22 @@ dependencyResolutionManagement {
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            // Compose integration (pulls in the engine), or just "…:filament:0.4.0" without Compose.
             implementation("io.github.erkko68.filament:filament-compose:0.4.0")
         }
     }
 }
 ```
 
-For the full setup (Compose Multiplatform plugin, FFM native runtime for Desktop, iOS framework linking, Web prebuilts) see **[Getting Started](docs/getting-started.md)**.
+The same coordinates work on every target — Gradle resolves one variant per target you declare, so you don't download the platforms you don't build for. (The one exception: the Desktop/JVM natives default to all four desktop platforms; one snippet narrows them — see [what Gradle actually downloads](docs/modules.md#what-gradle-actually-downloads).)
+
+For the full setup (Compose Multiplatform plugin, FFM native runtime for Desktop, iOS framework linking, Web prebuilts) see **[Getting Started](docs/getting-started.md)**, and **[Modules](docs/modules.md#dependencies-by-target)** for the per-target dependency table.
 
 ## Modules
 
 | Artifact | Description |
 | :--- | :--- |
-| `filament` | Core renderer — `Engine`, `Scene`, `View`, `Renderer`, `Camera`, `Texture`, `Material`. |
+| `filament` | Core renderer — `Engine`, `Scene`, `View`, `Renderer`, `Camera`, `Texture`, `Material`. No Compose dependency. |
 | `filament-compose` | Compose Multiplatform integration — `rememberFilamentScene` / `FilamentView` (and the `FilamentSceneView` shortcut), scene DSL, camera state, value-based post-processing. |
 | `gltfio` | glTF / GLB asset loading — `AssetLoader`, `FilamentAsset`, `Animator`. |
 | `filamat` | Runtime material compilation — `MaterialBuilder`. |
@@ -105,7 +122,8 @@ The public API stays as close as possible to the **Android Filament API**, so ex
 ### This project
 - **[API Reference](https://erkko68.github.io/filament-kmp/api/)** — generated KDoc for all published modules.
 - **[Getting Started](docs/getting-started.md)** — per-platform Gradle setup, first scene.
-- **[Modules](docs/modules.md)** — published artifacts, dependency graph, when you need what.
+- **[Modules](docs/modules.md)** — published artifacts, per-target dependencies, what Gradle downloads.
+- **[Using the Engine Without Compose](docs/engine.md)** — own render loop, own surface, headless rendering.
 - **[Platform Notes](docs/platform-notes.md)** — backends, gotchas (Windows JVM shutdown, web limits, iOS embedding).
 - **[Compose Integration](docs/compose/README.md)** — scene-vs-view model, `FilamentSceneView` / `rememberFilamentScene` / `FilamentView`, scene DSL, post-processing.
 - **[Repository Structure](docs/repo-structure.md)** — for contributors.
@@ -126,4 +144,4 @@ The web build is also deployed live to **[erkko68.github.io/filament-kmp](https:
 
 ## License
 
-Licensed under the [Apache License, Version 2.0](LICENSE). Filament itself is also Apache-2.0 licensed by Google.
+Licensed under the [Apache License, Version 2.0](LICENSE.md). Filament itself is also Apache-2.0 licensed by Google.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,11 +2,19 @@
 
 Welcome. These docs cover everything you need to build with `filament-kmp` — from a 5-minute Gradle setup to the lower-level Filament concepts the wrapper exposes.
 
+Filament KMP is two things stacked: **Kotlin Multiplatform bindings to the Filament engine**
+(`filament`, `gltfio`, `filament-utils`, `filamat`), and an **optional Compose Multiplatform
+layer** on top (`filament-compose`). Both are first-class — pick whichever fits your app.
+
 ## Getting started
 
 - **[Getting Started](getting-started.md)** — Add the dependency, configure each platform, and render your first scene.
-- **[Modules](modules.md)** — What each published artifact does, Maven coordinates, dependency graph.
+- **[Modules](modules.md)** — What each published artifact does, which dependency each target needs, and what Gradle actually downloads.
 - **[Platform Notes](platform-notes.md)** — Backend selection, per-platform gotchas, known issues.
+
+## Using the engine directly (no Compose)
+
+- **[Using the Engine Without Compose](engine.md)** — Own the render loop: `Engine` / `View` / `Renderer` / `SwapChain`, attaching to your own surface on each platform, headless rendering and readback, glTF loading, lifecycle and threading rules.
 
 ## Compose Multiplatform integration
 

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -1,0 +1,181 @@
+# Using the Engine Without Compose
+
+`filament-compose` is **optional**. The `filament`, `gltfio`, `filament-utils` and `filamat`
+modules are plain Kotlin Multiplatform bindings over the Filament C++ API — no Compose
+runtime, no Compose Gradle plugin, no `@Composable` anywhere. Depend on `filament` alone and
+you get `Engine`, `Scene`, `View`, `Renderer`, `Camera`, `Material`, `Texture` and the
+managers, with the same names and shapes as [Android Filament](https://google.github.io/filament/Filament.md.html).
+
+Use this path when you are:
+
+- rendering into a surface you already own (`SurfaceView`, `CAMetalLayer`, an LWJGL/GLFW window, a `<canvas>`),
+- rendering **headless** — thumbnails, product shots, server-side image generation, tests,
+- writing an engine/game loop that isn't driven by a UI framework,
+- porting existing Android Filament code to other targets.
+
+```kotlin
+// build.gradle.kts — no Compose plugin required
+commonMain.dependencies {
+    implementation("io.github.erkko68.filament:filament:0.4.0")
+    implementation("io.github.erkko68.filament:gltfio:0.4.0")        // optional
+    implementation("io.github.erkko68.filament:filament-utils:0.4.0") // optional
+}
+```
+
+See **[Modules](modules.md#dependencies-by-target)** for what each target needs.
+
+## The render loop
+
+Filament's object model is the same everywhere: one `Engine` owns everything, a `Renderer`
+draws a `View` (scene + camera + viewport) into a `SwapChain`.
+
+```kotlin
+val engine    = Engine.create()
+val scene     = engine.createScene()
+val camera    = engine.createCamera()
+val view      = engine.createView().apply {
+    this.scene = scene
+    this.camera = camera
+    viewport = Viewport(0, 0, width, height)
+}
+val renderer  = engine.createRenderer()
+val swapChain = engine.createSwapChain(NativeSurface(myNativeWindow))
+
+// One frame — call this from your own loop / display link / requestAnimationFrame.
+fun frame(frameTimeNanos: Long) {
+    if (renderer.beginFrame(swapChain, frameTimeNanos)) {
+        renderer.render(view)
+        renderer.endFrame()
+    }
+}
+```
+
+Populating the scene is ordinary Filament: build a `Material`, a `VertexBuffer`/`IndexBuffer`,
+attach them to an entity with `RenderableManager.Builder`, add the entity to the scene.
+
+```kotlin
+val sun = EntityManager.get().create()
+LightManager.Builder(LightManager.Type.SUN)
+    .direction(0.7f, -0.7f, 0f)
+    .intensity(100_000f)
+    .castShadows(true)
+    .build(engine, sun)
+scene.addEntity(sun)
+```
+
+## Where the surface comes from
+
+`Engine.createSwapChain(NativeSurface(...))` takes a platform handle. Each target's
+`NativeSurface` wraps a different type:
+
+| Target | `NativeSurface` takes | Typical source |
+| :--- | :--- | :--- |
+| Android | `Surface` | `SurfaceView`'s `SurfaceHolder.surface`, or a `TextureView`'s `SurfaceTexture` |
+| iOS (Kotlin/Native) | `COpaquePointer?` | a `CAMetalLayer` you added to your `UIView` |
+| JVM / Desktop | `Long` / `MemorySegment` — a raw `HWND`, X11 `Window`, `NSView*` or `CAMetalLayer*` | LWJGL: `glfwGetWin32Window` / `glfwGetX11Window` / `glfwGetCocoaWindow` |
+| Web (JS / Wasm) | `HTMLCanvasElement` | `document.getElementById("canvas")` |
+
+Android, iOS and web hand you a first-class surface object, so those are straightforward.
+On the **JVM there is no window toolkit in this library** — you bring your own window and
+pass its native handle. If you'd rather not, use the headless path below, or let
+`filament-compose` own the window.
+
+> [!TIP]
+> Every rule in [Threading model](platform-notes.md#threading-model) applies here and is
+> now *your* responsibility: create the `Engine` on one thread and call every `engine.*`
+> method from that same thread. Compose was doing this for you.
+
+## Headless rendering
+
+The portable non-Compose path: no window at all. Create a sized swap chain with the
+`CONFIG_READABLE` flag, render, and read the pixels back. Works on Android, iOS,
+macOS/Windows/Linux JVM — everything except web, where `Renderer.readPixels` is a no-op
+(see [Platform Notes](platform-notes.md#web--wasm)).
+
+```kotlin
+// Filament's SwapChain::CONFIG_READABLE — not yet exposed as a Kotlin constant.
+private const val CONFIG_READABLE = 0x2L
+
+val engine = Engine.create()
+val swapChain = engine.createSwapChain(width, height, CONFIG_READABLE)
+val renderer = engine.createRenderer().apply {
+    clearOptions = Renderer.ClearOptions().apply {
+        clearColor = doubleArrayOf(0.0, 0.0, 0.0, 1.0)
+        clear = true
+    }
+}
+// ... build scene / view / camera as above ...
+
+val pixels = ByteArray(width * height * 4)
+var done = false
+val pbd = Texture.PixelBufferDescriptor(
+    pixels, pixels.size, Texture.Format.RGBA, Texture.Type.UBYTE,
+) { done = true }
+
+if (renderer.beginFrame(swapChain, 0L)) {
+    renderer.render(view)
+    renderer.readPixels(0, 0, width, height, pbd)
+    renderer.endFrame()
+}
+while (!done) engine.flushAndWait()   // readback is asynchronous
+```
+
+Two things that bite:
+
+- **Render a few frames before the one you keep.** Shader compilation and the shadow /
+  post-processing passes need a frame or two to settle; the very first frame can be blank.
+- **Row order is backend-dependent.** Metal delivers rows top-down, OpenGL bottom-up.
+  Flip according to `engine.backend` if you're writing a PNG.
+
+The same pattern drives this repo's own rendering tests — see
+[`FrameProbe`](../kotlin/filament/src/commonTest/kotlin/io/github/erkko68/filament/testutils/FrameProbe.kt)
+for a complete, working implementation you can copy.
+
+## Loading a glTF model
+
+`gltfio` is independent of Compose too:
+
+```kotlin
+val provider = UbershaderProvider(engine)
+val assetLoader = AssetLoader.create(engine, provider, engine.getEntityManager())
+val asset = assetLoader.createAsset(glbBytes)!!
+
+val resourceLoader = ResourceLoader(engine)
+resourceLoader.loadResources(asset)      // must run before textures/morph targets exist
+scene.addEntities(asset.getEntities())
+
+// Teardown, in this order.
+resourceLoader.destroy()
+assetLoader.destroyAsset(asset)
+AssetLoader.destroy(assetLoader)
+provider.destroy()
+```
+
+`filament-utils` similarly gives you `Manipulator` (orbit / map / flight camera control),
+`KTX1Loader` and `HDRLoader` with no Compose involved.
+
+## Lifecycle
+
+You own every object you create. Destroy in reverse dependency order and only then the
+engine, or `engine.destroy()` will panic on live resources:
+
+```kotlin
+engine.destroySwapChain(swapChain)
+engine.destroyRenderer(renderer)
+engine.destroyView(view)
+engine.destroyScene(scene)
+engine.destroyCamera(camera)
+scene.remove(entity); engine.destroyEntity(entity)  // plus buffers, materials, instances
+engine.destroy()
+```
+
+## Mixing with Compose later
+
+Adopting the Compose DSL afterwards doesn't mean rewriting: `filament-compose` exposes the
+raw `Engine` through `FilamentEffect`, so engine-level code keeps working inside a
+`FilamentSceneView`. Going the other way, `rememberFilamentEngine` just wraps
+`Engine.create()`. See [Compose Integration](compose/README.md).
+
+---
+
+[← Back to docs index](README.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,8 +2,13 @@
 
 This guide walks you through adding Filament KMP to a Kotlin Multiplatform project and rendering your first scene on each supported target.
 
+There are two ways to use the library. The platform setup in step 3 — JDK floor, framework linking, web bundle — applies to both; the entry points shown there are the Compose ones.
+
+- **With Compose Multiplatform** — `filament-compose` owns the surface and the render loop; you declare the scene. This guide takes that route.
+- **Without Compose** — depend on `filament` alone and drive `Engine` / `Renderer` / `SwapChain` yourself, against your own window or fully headless. That route is documented in **[Using the Engine Without Compose](engine.md)**.
+
 > [!NOTE]
-> Filament KMP requires **Kotlin 2.0+**, **Compose Multiplatform 1.7+**, and **JDK 22+** (required by the Project Panama / FFM bindings used for Desktop/JVM).
+> Filament KMP requires **Kotlin 2.0+** and, for the Desktop/JVM target, **JDK 22+** (the floor for the Project Panama / FFM bindings). **Compose Multiplatform 1.7+** is needed only if you use `filament-compose`.
 
 ## 1. Add the Maven Central repository
 
@@ -41,7 +46,12 @@ kotlin {
 }
 ```
 
-If you're not using Compose and want to drive the engine directly, depend on `filament` instead of `filament-compose`. See **[Modules](modules.md)** for the full coordinates list and dependency graph.
+If you're not using Compose and want to drive the engine directly, depend on `filament` instead of `filament-compose` — it has no Compose dependency at all. See **[Using the Engine Without Compose](engine.md)**.
+
+> [!NOTE]
+> **You only download the targets you declare.** Kotlin Multiplatform publishes one variant per target, so an Android-only app never fetches the iOS klibs and a JS app never fetches the desktop natives. The single exception is the JVM/Desktop native runtime, which defaults to carrying all four desktop platforms — narrow it to one before packaging an installer. See **[What Gradle actually downloads](modules.md#what-gradle-actually-downloads)**.
+
+See **[Modules](modules.md)** for the full coordinates list, the per-target dependency table, and the dependency graph.
 
 ## 3. Configure each target
 
@@ -70,13 +80,14 @@ class MainActivity : ComponentActivity() {
 }
 ```
 
-### iOS / macOS
+### iOS
 
 The native Filament libraries ship in the Kotlin/Native klib, so there's nothing to download manually. Just declare the framework in your `iosMain` source set as usual:
 
 ```kotlin
 kotlin {
-    listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+    // Published Apple targets: iosArm64 (device) and iosSimulatorArm64. There is no iosX64.
+    listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
         iosTarget.binaries.framework {
             baseName = "Shared"
             isStatic = true

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -2,6 +2,8 @@
 
 Filament KMP is split into five Kotlin Multiplatform modules, mirroring Filament's own module structure. Each is published independently to Maven Central so you only depend on what you need.
 
+Only **`filament-compose`** involves Compose. The other four are plain Kotlin bindings over the Filament API and work in any Kotlin code — a game loop, a headless renderer, an existing `SurfaceView` app. See **[Using the Engine Without Compose](engine.md)**.
+
 > [!NOTE]
 > All Kotlin modules are published under the group **`io.github.erkko68.filament`**.
 > The JVM/Desktop native runtime — a single Project Panama (FFM) module — is published as **`io.github.erkko68.filament-ffm:filament-ffm`** and pulled in transitively, so you never add it by hand.
@@ -14,10 +16,71 @@ Filament KMP is split into five Kotlin Multiplatform modules, mirroring Filament
 | Use case | Add |
 | :--- | :--- |
 | Compose Multiplatform 3D scene | `filament-compose` |
+| Driving the engine yourself — own render loop, own surface, headless | `filament` |
 | Load glTF / GLB models | `gltfio` |
-| Camera manipulators, HDR / KTX loading | `filament-utils` |
-| Driving Filament directly (no Compose) | `filament` |
+| Camera manipulators, HDR / KTX loading, math types | `filament-utils` |
 | Compile materials at runtime | `filamat` |
+
+`filament-compose` pulls in `filament`; the others are independent add-ons. None of
+`filament`, `gltfio`, `filament-utils` or `filamat` depends on Compose.
+
+## Dependencies by target
+
+The coordinates are identical on every target — Kotlin Multiplatform resolves the right
+variant per target, so a single `commonMain` declaration is normally all you write.
+What differs is the extra platform setup around it:
+
+| Target | Kotlin dependency | Also required |
+| :--- | :--- | :--- |
+| **Android** | `io.github.erkko68.filament:filament` | Nothing. The official `com.google.android.filament:filament-android` AAR comes in transitively. `compileSdk 34`, `minSdk 24`. |
+| **JVM / Desktop** (macOS, Windows, Linux) | same | **JDK 22+** at build and run time. The native runtime `io.github.erkko68.filament-ffm:filament-ffm` is transitive — nothing to add by hand. See [narrowing the natives](#what-gradle-actually-downloads). |
+| **iOS** (`iosArm64`, `iosSimulatorArm64`) | same | Nothing. The Filament static libraries are inside the klib. Link your framework as `isStatic = true`. |
+| **Web** (`js`, `wasmJs`) | same | `filament.js` + `filament.wasm` copied into `src/jsMain/resources/` — they are **not** pulled in by Gradle. See [Platform Notes](platform-notes.md#filamentjs-and-wasm-bundle). |
+
+> [!NOTE]
+> Published Apple targets are **`iosArm64`** and **`iosSimulatorArm64`** only. There is no
+> `iosX64` (Intel simulator) or standalone `macosArm64`/`macosX64` Kotlin/Native target —
+> desktop macOS is served by the JVM target.
+
+Targeting only one platform is perfectly normal — a JVM-only or Android-only Gradle module
+declares the dependency in `dependencies { }` exactly like any other library:
+
+```kotlin
+// A plain JVM project — no KMP plugin, no Compose.
+dependencies {
+    implementation("io.github.erkko68.filament:filament:0.4.0")
+}
+```
+
+## What Gradle actually downloads
+
+**You do not get every platform's binaries.** Kotlin Multiplatform publishes one variant per
+target and Gradle resolves only the ones your build declares: an Android-only app never
+downloads the iOS klibs or the web artifacts, a JS app never downloads the ~13 MB desktop
+natives. If your project declares three targets, you download three targets' artifacts.
+
+The one exception is the **JVM/Desktop native runtime**. `filament-ffm` defaults to depending
+on all four desktop platform modules (`macos-arm64`, `linux-x64`, `linux-arm64`,
+`windows-x64`, ~13 MB each), so that a plain `./gradlew run` works on any developer machine
+with zero configuration. Two ways to narrow it to the one you need — worth doing before
+building an installer, since `jpackage` / Compose Desktop bundle the whole runtime classpath:
+
+```kotlin
+// Option A — declare your os/arch and Gradle picks the matching variant automatically.
+configurations.matching { it.isCanBeResolved }.configureEach {
+    attributes {
+        attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(OperatingSystemFamily.MACOS))
+        attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(MachineArchitecture.ARM64))
+    }
+}
+
+// Option B — depend on one platform runtime directly; it excludes its siblings.
+dependencies {
+    implementation("io.github.erkko68.filament-ffm:filament-ffm-runtime-macos-arm64:0.X.0")
+}
+```
+
+Full details in [`java/README.md`](../java/README.md).
 
 ## Published artifacts
 
@@ -43,7 +106,7 @@ The core renderer. Wraps Filament's `Engine`, `Scene`, `View`, `Renderer`, `Came
 implementation("io.github.erkko68.filament:filament:0.4.0")
 ```
 
-Use this directly only if you're not using Compose, or if you need an API not yet exposed by `filament-compose`. The Compose DSL provides an escape hatch (`FilamentEffect`) that hands you the raw `Engine`, so most apps don't need to depend on `filament` directly.
+This is the whole engine and it stands on its own — no Compose runtime, no Compose Gradle plugin. Depend on it when you drive the render loop yourself, render into a surface you already own, or render headless; see **[Using the Engine Without Compose](engine.md)**. Compose users get it transitively via `filament-compose` and can reach the raw `Engine` through the `FilamentEffect` escape hatch, so they rarely declare it explicitly.
 
 Upstream reference: **[Filament Engine](https://google.github.io/filament/Filament.md.html)**.
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -42,11 +42,11 @@ In a pure Compose app none of that applies: layouts are code, theming reacts to 
 
 This is standard practice for graphics, video, and game apps on Android. The `SurfaceView` still receives `surfaceChanged` on resize, so the viewport and aspect ratio update correctly without any extra code.
 
-## iOS / macOS (Kotlin/Native)
+## iOS (Kotlin/Native)
 
 - Renders via `CAMetalLayer` embedded in a `UIKitView`.
 - Use static frameworks (`isStatic = true`) — keeps the Filament symbols inside your app binary and avoids dynamic-library loader issues.
-- macOS via JVM (Compose Desktop) and macOS via Kotlin/Native are **different code paths**. The Kotlin/Native path binds the C wrapper via `cinterop`; the JVM path binds the same C wrapper via Project Panama (FFM).
+- Published Apple targets are **`iosArm64`** and **`iosSimulatorArm64`**; there is no `iosX64` and no standalone macOS Kotlin/Native target. Desktop macOS is served by the **JVM** target, which binds the same C wrapper through Project Panama (FFM) rather than `cinterop` — a different code path with the same API.
 
 ### iOS Simulator: shadows render black
 

--- a/docs/upgrading-filament.md
+++ b/docs/upgrading-filament.md
@@ -186,17 +186,16 @@ which layers it reaches.
 
 **The JS actual** depends on whether the method is in `jsbindings.cpp`:
 
-- **Registered in `jsbindings.cpp`** (reachable at runtime): add the declaration to the overlay
-  `web/src/webMain` as a typed external declaration, then call it from the
-  `jsMain` actual. Instance methods are added by **declaration merging** — reopen the class as an
-  `interface` of the same name:
-  ```ts
-  export interface ColorGrading$Builder {
-      fastMath(fastMath: boolean): ColorGrading$Builder;
+- **Registered in `jsbindings.cpp`** (reachable at runtime): add the member to the
+  hand-maintained Kotlin externals under `web/src/webMain/kotlin/…/web/` (one file per
+  upstream type), then call it from the `jsMain` actual:
+  ```kotlin
+  external class ColorGrading$Builder {
+      fun fastMath(fastMath: Boolean): ColorGrading$Builder
   }
   ```
-  (Statics and field/typo corrections can't be expressed by merging — those go in
-  `js/patches/filament.dts-overrides.json`. See [`js/README.md`](../js/README.md).)
+  Check the signature against `jsbindings.cpp`, not against upstream's `filament.d.ts` —
+  the d.ts lags the real bindings. See [`web/README.md`](../web/README.md).
 - **Not in `jsbindings.cpp`** (no Web binding exists — e.g. `Engine.Builder` has no JS
   equivalent): make the `jsMain` actual a no-op stub and mark it:
   ```kotlin


### PR DESCRIPTION
The docs read as if `filament-compose` were the only way in. It isn't — `filament`, `gltfio`, `filament-utils` and `filamat` have no Compose dependency at all. This makes that visible and answers the two questions a non-Compose user hits first: *which artifact do I add for my target*, and *am I about to download every platform's binaries?*

## New

**[`docs/engine.md`](docs/engine.md)** — using the engine directly:
- the `Engine` / `View` / `Renderer` / `SwapChain` loop
- where the native surface comes from on each target (`Surface`, `CAMetalLayer`, `HWND`/X11/`NSView` via LWJGL, `HTMLCanvasElement`) — including the honest note that the JVM ships no window toolkit
- headless rendering + `readPixels` readback: the portable path, with the two gotchas (warm-up frames, backend row order) and a pointer to `FrameProbe` as a working implementation
- raw `gltfio` loading, teardown order, threading rules that Compose was handling for you

Every snippet is checked against real code in the repo, not written from memory.

## Changed

- **`docs/modules.md`** — *Dependencies by target* table, and *What Gradle actually downloads*: one variant per declared target, with the real exception spelled out (`filament-ffm` defaults to all four desktop natives, ~13 MB each) and both snippets to narrow it before packaging an installer.
- **`docs/getting-started.md`** — a Compose / no-Compose fork up front; Compose MP is no longer stated as a hard requirement of the library.
- **`README.md` / `docs/README.md`** — reframed as "KMP bindings + optional Compose layer", with a non-Compose snippet. The unofficial-project note now sits below the description rather than above it.

## Fixes found while verifying

- `getting-started.md` told users to declare `iosX64()` — not a published target (only `iosArm64` + `iosSimulatorArm64`), so following it gave an unresolved dependency.
- `platform-notes.md` described a macOS Kotlin/Native code path; there is no standalone macOS K/N target — desktop macOS is the JVM target.
- `upgrading-filament.md` still documented the retired Karakum d.ts-overlay flow (TypeScript declaration merging, `patches/filament.dts-overrides.json` — a file that no longer exists); replaced with the current hand-maintained Kotlin externals under `web/src/webMain`.
- Two dead links (`LICENSE`, `../js/README.md`).

## Not done

`SwapChain.CONFIG_READABLE` still isn't exposed as a Kotlin constant — it's hardcoded `0x2L` in both the tests and `filament-compose`, so the headless example spells the literal out. Worth adding next time the `SwapChain` expect/actual set is touched; out of scope for a docs PR.