### PR TITLE
fix(compose): release the Surface backing a transparent Android view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Each entry is one line; click the version link at the bottom for the full diff.
 
 ## [Unreleased]
 
+### Fixed
+- **Leaked `Surface` on transparent Android views** (`filament-compose`): the `TextureView` path wrapped the `SurfaceTexture` in a `Surface` and never released it, leaving it to the finalizer.
+
 ### Added
 - **Option-struct fields missing from common** (`filament`): `View.SoftShadowOptions.maxPenumbraRatio`/`maxSearchRadius`, `View.DepthOfFieldOptions.cocAspectRatio`, `LightManager.ShadowOptions.maxPenumbraRatio`/`maxSearchRadius`, `Engine.Config.disableParallelShaderCompile`/`disableHandleUseAfterFreeCheck`/`assertNativeWindowIsValid`, and a nested `View.AmbientOcclusionOptions.Gtao` (6 fields) so GTAO can be tuned and not just selected. The last three groups are `@PlatformGap`-annotated on web — see [Platform notes](docs/platform-notes.md).
 - **`check-common-api.sh` audits struct fields** (build): the audit compared classes, nested types, constants and method *names*, so the contents of every option struct went unchecked — Filament's Android bindings expose them as bare fields. Findings are now attributed to their owning nested type, so ignoring `Renderer.FrameInfo` ignores its fields too, and `View`'s two different `maxPenumbraRatio` fields are distinguishable.

--- a/kotlin/filament-compose/src/androidDeviceTest/kotlin/io/github/erkko68/filament/compose/internal/FilamentSurfaceTextureListenerTest.kt
+++ b/kotlin/filament-compose/src/androidDeviceTest/kotlin/io/github/erkko68/filament/compose/internal/FilamentSurfaceTextureListenerTest.kt
@@ -1,0 +1,50 @@
+package io.github.erkko68.filament.compose.internal
+
+import android.graphics.SurfaceTexture
+import android.view.Surface
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/** Guards the [Surface] ownership in the TextureView path: created once, released on destroy. */
+class FilamentSurfaceTextureListenerTest {
+    private val surfaceTexture = SurfaceTexture(0)
+
+    @AfterTest
+    fun tearDown() = surfaceTexture.release()
+
+    @Test
+    fun releasesSurfaceAfterDestroyCallback() {
+        var surface: Surface? = null
+        var destroyedWhileValid = false
+        val listener = filamentSurfaceTextureListener(
+            onAvailable = { s, _, _ -> surface = s },
+            onResized = { _, _ -> },
+            // The swapchain teardown must still see a live surface.
+            onDestroyed = { destroyedWhileValid = surface?.isValid == true },
+        )
+
+        listener.onSurfaceTextureAvailable(surfaceTexture, 64, 32)
+        val created = assertNotNull(surface)
+        assertTrue(created.isValid)
+
+        assertTrue(listener.onSurfaceTextureDestroyed(surfaceTexture))
+        assertTrue(destroyedWhileValid, "surface was released before the destroy callback ran")
+        assertFalse(created.isValid, "surface leaked — not released on destroy")
+    }
+
+    @Test
+    fun forwardsSizeChanges() {
+        var size: Pair<Int, Int>? = null
+        val listener = filamentSurfaceTextureListener(
+            onAvailable = { _, _, _ -> },
+            onResized = { w, h -> size = w to h },
+            onDestroyed = {},
+        )
+        listener.onSurfaceTextureSizeChanged(surfaceTexture, 128, 64)
+        assertEquals(128 to 64, size)
+    }
+}

--- a/kotlin/filament-compose/src/androidMain/kotlin/io/github/erkko68/filament/compose/internal/FilamentSurface.android.kt
+++ b/kotlin/filament-compose/src/androidMain/kotlin/io/github/erkko68/filament/compose/internal/FilamentSurface.android.kt
@@ -48,36 +48,20 @@ internal actual fun FilamentSurface(
                 if (transparent) {
                     TextureView(context).apply {
                         isOpaque = false
-                        surfaceTextureListener = object : TextureView.SurfaceTextureListener {
-                            override fun onSurfaceTextureAvailable(
-                                surfaceTexture: SurfaceTexture,
-                                width: Int,
-                                height: Int
-                            ) {
-                                val surface = Surface(surfaceTexture)
+                        surfaceTextureListener = filamentSurfaceTextureListener(
+                            onAvailable = { surface, width, height ->
                                 swapChainRef.value = engine.createSwapChain(
                                     NativeSurface(surface),
                                     SWAP_CHAIN_CONFIG_TRANSPARENT,
                                 )
                                 updateViewport(width, height)
-                            }
-
-                            override fun onSurfaceTextureSizeChanged(
-                                surfaceTexture: SurfaceTexture,
-                                width: Int,
-                                height: Int
-                            ) {
-                                updateViewport(width, height)
-                            }
-
-                            override fun onSurfaceTextureDestroyed(surfaceTexture: SurfaceTexture): Boolean {
+                            },
+                            onResized = ::updateViewport,
+                            onDestroyed = {
                                 swapChainRef.value?.let { engine.destroySwapChain(it) }
                                 swapChainRef.value = null
-                                return true
-                            }
-
-                            override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) {}
-                        }
+                            },
+                        )
                     }
                 } else {
                     SurfaceView(context).apply {
@@ -115,4 +99,35 @@ internal actual fun FilamentSurface(
             renderer.endFrame()
         }
     }
+}
+
+/**
+ * TextureView listener that owns the [Surface] it wraps around the [SurfaceTexture]: [onDestroyed]
+ * runs first (the swapchain still needs the surface), then the surface is released instead of being
+ * left to the finalizer.
+ */
+internal fun filamentSurfaceTextureListener(
+    onAvailable: (Surface, width: Int, height: Int) -> Unit,
+    onResized: (width: Int, height: Int) -> Unit,
+    onDestroyed: () -> Unit,
+): TextureView.SurfaceTextureListener = object : TextureView.SurfaceTextureListener {
+    private var surface: Surface? = null
+
+    override fun onSurfaceTextureAvailable(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
+        val s = Surface(surfaceTexture).also { surface = it }
+        onAvailable(s, width, height)
+    }
+
+    override fun onSurfaceTextureSizeChanged(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
+        onResized(width, height)
+    }
+
+    override fun onSurfaceTextureDestroyed(surfaceTexture: SurfaceTexture): Boolean {
+        onDestroyed()
+        surface?.release()
+        surface = null
+        return true
+    }
+
+    override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) {}
 }


### PR DESCRIPTION
The `TextureView` path in `FilamentSurface.android.kt` wrapped the `SurfaceTexture` in a `Surface` and never released it — the native reference survived until the finalizer ran.

The anonymous `SurfaceTextureListener` is now a named `filamentSurfaceTextureListener(...)` factory that owns the `Surface`: `onDestroyed` runs first (the swapchain still needs a live surface), then `release()`. Extracting it is also what makes the ownership testable — inside the `AndroidView` factory lambda the listener was unreachable.

`FilamentSurfaceTextureListenerTest` is a plain instrumented test: no engine, no swapchain, no GPU, just a `SurfaceTexture(0)` and `Surface.isValid`. Verified on a Pixel 9 Pro emulator (API 36) — 2/2 pass, and reverting the `release()` call fails it with `surface leaked — not released on destroy`.