### PR TITLE
Give the API docs a version dropdown and deploy them per release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ repeat runs skip the download.
 | :--- | :--- | :--- |
 | [`ci.yml`](ci.yml) | **push to `main`** and **every PR** (no path filters — docs included); **manual dispatch** (job picker) | One job per platform (jvm matrix / js / wasm / ios / android). Each job sets up + builds the native library once, then runs **build → test → sample** as sequential steps that reuse those outputs. The sample steps build the `samples/` apps (a composite `includeBuild` of this repo) to verify the umbrella library is consumable end-to-end — catching breakage pure unit tests miss (Compose config, resource loading, native linking). See [Running CI](#running-ci). |
 | [`status-{jvm,js,wasm,ios,android}.yml`](status-jvm.yml) | `workflow_run` after **CI** completes on `main` | Reflect each platform job's conclusion from the latest `main` CI run into their own conclusion, powering the per-platform README badges. A *skipped* job (verified-merge, see below) counts as passing — only a real failure turns a badge red. |
-| [`pages.yml`](pages.yml) | push to `main` touching the web target (`web/**`, `kotlin/**/src/**`, `samples/webApp/**`, … — see its `paths:` filter) / manual dispatch | Builds the `webApp` sample's production webpack bundle and deploys it to GitHub Pages. Already scoped to web-relevant paths, so docs changes never trigger it. |
+| [`pages.yml`](pages.yml) | push to `main` touching the web target (`web/**`, `kotlin/**/src/**`, `samples/webApp/**`, … — see its `paths:` filter) / manual dispatch | Builds the `webApp` sample's production webpack bundle and the Dokka API docs, and deploys both to GitHub Pages (docs under `/api`). Already scoped to web-relevant paths, so docs changes never trigger it. Also runs on a **published release**, which is what archives that version's docs on the orphan `docs-archive` branch for re-publishing under `/api/older/<version>` — see [Versioned API docs](#versioned-api-docs). |
 | [`publish.yml`](publish.yml) | tag matching `[0-9]*` / manual dispatch | Releases to Maven Central, then cuts the matching GitHub release with that version's CHANGELOG section as its notes. See [Releasing](#releasing) below. |
 
 ## Running CI
@@ -58,6 +58,24 @@ The publish workflow is a two-phase pipeline:
    directory, then invokes `publishAllPublicationsToMavenCentralRepository` for every module
    with `-PcArtifactsDir=...` so the `:java` module bundles every platform's native into its
    resources (the `:kotlin:*` jvm artifacts pick it up transitively).
+
+### Versioned API docs
+
+The docs job labels the site with `libVersion` from `gradle.properties` and Dokka's versioning
+plugin renders a version dropdown. Only a published release goes live — pushes to `main` and PRs
+build the site and throw it away, so the deployed docs always describe a released version. Released versions live as `<version>/` directories on the orphan
+**`docs-archive`** branch: every run clones it into `build/previousDocs` before generating, but
+only a **published release** writes back — it force-pushes a single fresh commit with the tag's
+docs added (a store, not a history, otherwise the repo would gain a full copy of the site per
+build). Pushes to `main` still redeploy `/api`, they just never touch the archive, so each
+version is archived once, built from its tag.
+
+A generated site is ~90 MB and GitHub Pages caps one site at 1 GB, so the archive keeps only the
+four newest versions (the tags stay, so anything older can be rebuilt).
+
+The archive starts empty, so the first release after this landed shows no dropdown — it appears
+from the second one on. Releases older than that are not backfilled; their docs can still be
+rebuilt from their tags with `./gradlew dokkaGenerate`.
 
 ### How to cut a release
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,13 @@ on:
       - 'gradle.properties'
       - 'buildSrc/**'
       - '.github/workflows/pages.yml'
+  # A published release is the only event that DEPLOYS, and the only one that writes
+  # a version into the docs archive — the live site therefore always matches a
+  # release, never an in-flight main. (A `tags:` filter on `push` would be dead
+  # here: path filters never match a tag push.) publish.yml creates the release once
+  # Maven Central accepts.
+  release:
+    types: [published]
   workflow_dispatch:
 
 # Concurrency: per-ref so PR runs don't cancel a main deploy; within a ref the
@@ -68,6 +75,9 @@ jobs:
           path: samples/webApp/build/dist/js/productionExecutable
 
   docs:
+    # `contents: write` so the docs archive branch can be pushed (see below).
+    permissions:
+      contents: write
     # macOS: Dokka documents every platform, so it builds each one for its
     # analysis classpath — iOS cinterop needs Xcode, plus JVM (:java/jextract),
     # JS externals and Android. iOS native is only buildable on macOS.
@@ -85,11 +95,53 @@ jobs:
       - name: Accept Android SDK licenses
         run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
 
+      # Previously published versions live as <version>/ dirs on the orphan
+      # `docs-archive` branch; Dokka's versioning plugin renders the dropdown from
+      # them and re-emits them under api/older/, so one deploy serves every version.
+      # Fetched only when this run deploys or archives — it's a ~350 MB clone, a
+      # validation build proves as much rendering the current version alone, and the
+      # archive push force-pushes this directory, so it must be complete first.
+      - name: Restore archived doc versions
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        run: |
+          git clone -q --depth 1 --single-branch --branch docs-archive \
+            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}" \
+            build/previousDocs || mkdir -p build/previousDocs
+          rm -rf build/previousDocs/.git
+          # Never let the archive hold the version we're about to render — a re-run or a
+          # manual dispatch would otherwise list the same version twice.
+          rm -rf "build/previousDocs/$(grep '^libVersion=' gradle.properties | cut -d= -f2)"
+
       - name: Generate API docs
         # Aggregates :kotlin:filament, :kotlin:filamat, :kotlin:filament-utils,
         # :kotlin:gltfio, :kotlin:filament-compose into build/dokka/html (Dokka v2).
         # :java and :web modules are excluded (FFM internals / generated externals).
+        # The version label comes from libVersion in gradle.properties.
         run: ./gradlew dokkaGenerate --no-configuration-cache
+
+      # Releases only, so a version lands in the archive exactly once, built from its
+      # tag; other events generate the docs purely to prove Dokka still works.
+      # Force-push a single orphan commit — the branch is a store, not a history, so
+      # the repo doesn't grow a copy of the whole site per build.
+      - name: Archive this version's docs
+        if: github.event_name == 'release'
+        run: |
+          version=$(grep '^libVersion=' gradle.properties | cut -d= -f2)
+          rm -rf "build/previousDocs/$version"
+          cp -R build/dokka/html "build/previousDocs/$version"
+          rm -rf "build/previousDocs/$version/older"  # don't archive the nested copies
+          # One version is ~90 MB and GitHub Pages caps a site at 1 GB, so keep only
+          # the newest few; older releases stay reachable through their git tags.
+          cd build/previousDocs
+          ls -1 | sort -Vr | tail -n +5 | while read -r stale; do rm -rf "$stale"; done
+          git init -q -b docs-archive
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -qm "API docs @ $version"
+          git push -qf \
+            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}" \
+            docs-archive
 
       - uses: actions/upload-artifact@v7
         with:
@@ -97,8 +149,9 @@ jobs:
           path: build/dokka/html
 
   deploy:
-    # Build-only on PRs; deploy only from main pushes / manual dispatch.
-    if: github.event_name != 'pull_request'
+    # Pushes to main and PRs are validation builds only — a release (or a manual
+    # dispatch, which publishes whatever the chosen ref holds) is what goes live.
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: [web, docs]
     runs-on: ubuntu-latest
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Each entry is one line; click the version link at the bottom for the full diff.
 
 ## [Unreleased]
 
+### Changed
+- **Versioned API docs**: the published Dokka site now carries a version dropdown; older releases stay online under `/api/older/<version>`.
+
 ### Fixed
 - **Leaked `Surface` on transparent Android views** (`filament-compose`): the `TextureView` path wrapped the `SurfaceTexture` in a `Surface` and never released it, leaving it to the finalizer.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,19 @@ dependencies {
     dokka(project(":kotlin:filament-utils"))
     dokka(project(":kotlin:gltfio"))
     dokka(project(":kotlin:filament-compose"))
+    dokkaPlugin(libs.dokka.versioningPlugin)
+}
+
+// ── API docs versioning ───────────────────────────────────────────────────────
+// The versioning plugin renders the version dropdown and copies each directory of
+// build/previousDocs/<version> into the site under `older/`, so one deploy serves
+// every release. CI restores that dir from the `docs-archive` branch and pushes the
+// freshly built version back; locally it's absent and only this version renders.
+dokka {
+    pluginsConfiguration.versioning {
+        version = providers.gradleProperty("libVersion").getOrElse("0.1.0-SNAPSHOT")
+        olderVersionsDir = layout.buildDirectory.dir("previousDocs")
+    }
 }
 
 // ── Test-coverage aggregation (Kover) ─────────────────────────────────────────

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref 
 compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "composeMultiplatform" }
 vanniktech-publish-gradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "vanniktech-publish" }
 dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+dokka-versioningPlugin = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
 kover-gradlePlugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commons-compress" }
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
The published Dokka site is unversioned — it always tracks `main`, so a user has no way to read the API of the release they actually depend on.

## What changes

- **Dokka versioning plugin** (root `build.gradle.kts` only — the aggregating publication task re-renders module pages, so the dropdown reaches every page without touching the convention plugin). Version label comes from `libVersion`.
- **`docs-archive` branch** — an orphan branch holding `<version>/` directories. `pages.yml` clones it into `build/previousDocs` before generating; Dokka re-emits those under `/api/older/<version>` and links the dropdown to the equivalent page in each. Force-pushed as a single commit so the repo doesn't accumulate a copy of the site per release.
- **Deploy is now release-only.** `release: [published]` (a `tags:` filter under `push` would never fire — path filters don't match tag pushes) is the only event that deploys and the only one that archives. Pushes to `main` and PRs still build web + docs, they just don't publish, so the live site always describes a released version.
- The archive keeps the 4 newest versions: one site measures 90 MB and GitHub Pages caps a site at 1 GB.

## Verified locally

`dokkaGenerate` with a seeded `build/previousDocs/0.3.1`: `older/0.3.1/` copied into the output, `versions-dropdown` markup present on both the root and module pages, deep-linking to `older/0.3.1/kotlin/filament-utils/index.html`.

## Rollout

The archive starts empty, so the first release after this merges shows no dropdown; it appears from the second release on. Older releases are not backfilled.